### PR TITLE
Refactor hidden fields logic

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -59,7 +59,7 @@ module.exports = function (options) {
 
   app.get('/:collection', hiddenFields, function (req, res, next) {
     var collectionName = req.params.collection;
-    req.storage.list(collectionName, req.fields, function (err, docs) {
+    req.storage.list(collectionName, function (err, docs) {
       if (err) { return next(err); }
       res.jsonp({ result: docs });
     });
@@ -69,7 +69,7 @@ module.exports = function (options) {
     var collectionName = req.params.collection;
     var id             = req.params.id;
 
-    req.storage.retrieve( collectionName, id, req.fields, function (err, doc) {
+    req.storage.retrieve( collectionName, id, function (err, doc) {
       if (err) {
         next(err);
       } else if (doc) {

--- a/src/middleware/hidden-fields.js
+++ b/src/middleware/hidden-fields.js
@@ -8,7 +8,7 @@ var async = require('async');
  *
  * This piece of middleware handles field visibility on the models. It looks for
  * documents that match the current collection and if it finds any field specs then
- * it exposes them on `req.fields`.
+ * it exposes them on `req.storage.fields`.
  *
  * The fields spec is passed to mongo's `find` method, which accepts fields
  * as its second argument and retricts the returned documents based on that.
@@ -16,7 +16,7 @@ var async = require('async');
  * Example
  *
  *     app.get('/:collection', hiddenFields, function(req, res, next) {
- *       // req.fields will be populated based on the `:collection` param.
+ *       // req.storage.fields will be populated based on the `:collection` param.
  *     });
  *
  * @param {object} req The express request object
@@ -24,7 +24,7 @@ var async = require('async');
  * @param {object} next The express next function
  */
 function hiddenFields(req, res, next) {
-  req.fields = {
+  var fields = {
     all: {}
   };
 
@@ -38,7 +38,7 @@ function hiddenFields(req, res, next) {
   if (globallyHidden) {
     globallyHidden.forEach(function(hidden) {
       if (hidden.collection === req.params.collection) {
-        _.extend(req.fields.all, hidden.fields);
+        _.extend(fields.all, hidden.fields);
       }
     });
   }
@@ -67,12 +67,14 @@ function hiddenFields(req, res, next) {
     var documentSpecific = results[1];
 
     collectionWide.forEach(function(doc) {
-      _.extend(req.fields.all, doc.fields);
+      _.extend(fields.all, doc.fields);
     });
 
     documentSpecific.forEach(function(doc) {
-      req.fields[doc.doc] = doc.fields;
+      fields[doc.doc] = doc.fields;
     });
+
+    req.storage.fields = fields;
 
     next();
   });

--- a/src/storage.js
+++ b/src/storage.js
@@ -20,6 +20,7 @@ function Storage(databaseName) {
   assert(databaseName, "Need to provide a database name");
   this.databaseName = databaseName;
   this.db = mongoclient.db(databaseName);
+  this.fields = {all: {}};
 }
 
 Storage.generateID = function () {
@@ -86,20 +87,15 @@ Storage.prototype.store = function (collectionName, doc, cb) {
 /*
   Retrieve a document from the database.
 */
-Storage.prototype.retrieve = function (collectionName, id, fields, cb) {
-  if (typeof fields === 'function') {
-    cb = fields;
-    fields = {};
-  }
-  fields = fields || {};
-
+Storage.prototype.retrieve = function (collectionName, id, cb) {
+  var fields = this.fields;
   // If there are document specific hidden fields add them to fields.all
   if (fields[id]) {
     _.extend(fields.all, fields[id]);
   }
 
   var collection = this.db.collection(collectionName);
-  collection.findOne({_id: id}, fields.all || {}, function (err, doc) {
+  collection.findOne({_id: id}, fields.all, function (err, doc) {
     if (err) {
       return cb(err);
     }
@@ -114,15 +110,10 @@ Storage.prototype.retrieve = function (collectionName, id, fields, cb) {
 /*
   List documents in the database.
 */
-Storage.prototype.list = function (collectionName, fields, cb) {
-  if (typeof fields === 'function') {
-    cb = fields;
-    fields = {};
-  }
-  fields = fields || {};
-
+Storage.prototype.list = function (collectionName, cb) {
+  var fields = this.fields;
   var collection = this.db.collection(collectionName);
-  var cursor = collection.find({}, fields.all || {});
+  var cursor = collection.find({}, fields.all);
   
   cursor.toArray(function (err, docs) {
 


### PR DESCRIPTION
Rather than the route handlers having to know that `req.fields` exist and passing it to the storage adapter, we instead expose the hidden fields directly to the storage adapter, so the route handlers can just use the `Storage` interface as normal without having to remember to pass through `req.fields`.

This makes hidden fields a mostly Storage-internal implementation, which will hopefully keep the external interface a bit cleaner.
