### PR TITLE
Store each translation as a separate key in elasticsearch

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -10,9 +10,13 @@ function isValidLanguage(language) {
 /**
  * Takes an object and a language and flattens any language keys of
  * that object to use the specified language, or the default one.
+ *
+ * If includeTranslations is true then it will turn the other languages into
+ * keys like name_en, name_ru etc. (Default false)
  */
-function i18n(objectWithLanguages, langs, defaultLang) {
+function i18n(objectWithLanguages, langs, defaultLang, includeTranslations) {
   langs = langs || [];
+  includeTranslations = includeTranslations || false;
   var obj = {};
   // Detect keys that need translating
   _.each(objectWithLanguages, function(value, key) {
@@ -30,7 +34,7 @@ function i18n(objectWithLanguages, langs, defaultLang) {
     if (_.isArray(value)) {
       obj[key] = value.map(function(nestedValue) {
         if (_.isObject(nestedValue) && !_.isArray(nestedValue)) {
-          return i18n(nestedValue, langs, defaultLang);
+          return i18n(nestedValue, langs, defaultLang, includeTranslations);
         } else {
           return nestedValue;
         }
@@ -48,9 +52,14 @@ function i18n(objectWithLanguages, langs, defaultLang) {
       });
       if (!obj[key]) {
         obj[key] = value[defaultLang] || '';
+        if (includeTranslations) {
+          _.each(value, function(translation, language) {
+            obj[key + '_' + language] = translation;
+          });
+        }
       }
     } else {
-      obj[key] = i18n(value, langs, defaultLang);
+      obj[key] = i18n(value, langs, defaultLang, includeTranslations);
     }
   });
   return obj;

--- a/src/mongoose/elasticsearch.js
+++ b/src/mongoose/elasticsearch.js
@@ -12,6 +12,7 @@
 var elasticsearch = require('elasticsearch');
 var filter = require('../filter');
 var paginate = require('../paginate');
+var i18n = require('../i18n');
 
 module.exports = elasticsearchPlugin;
 
@@ -37,25 +38,8 @@ function elasticsearchPlugin(schema) {
         }
       }
     });
-    for (var key in doc) {
-      if (!doc.hasOwnProperty(key)) {
-        continue;
-      }
-      var value = doc[key];
-      if (typeof value !== 'string') {
-        continue;
-      }
 
-      if (!schema.path(key) || key === 'id' || key === 'slug') {
-        continue;
-      }
-
-      // If we've got this far then we have a popolo string field, so we turn it into an object.
-      doc[key] = {};
-      doc[key][schema.options.toJSON.defaultLanguage || 'en'] = value;
-    }
-
-    return doc;
+    return i18n(doc, [], schema.options.toJSON.defaultLanguage || 'en', true);
   };
 
   /**

--- a/test/search.js
+++ b/test/search.js
@@ -47,7 +47,7 @@ describe("Search", function() {
         if (err) {
           return done(err);
         }
-        assert.equal("John Smith", result._source.name.en);
+        assert.equal("John Smith", result._source.name);
         done();
       });
     }
@@ -84,6 +84,35 @@ describe("Search", function() {
         done();
       });
     }
+  });
+
+  describe("toElasticsearch", function() {
+    it("turns translated objects into multiple values", function(done) {
+      var person = new Person({
+        _id: 'test',
+        name: {
+          en: 'One',
+          es: 'Uno'
+        },
+        foo: [
+          {bar: {en: 'Bar', es: 'Baro'}}
+        ]
+      });
+
+      person.save(function(err) {
+        assert.ifError(err);
+        var doc = person.toElasticsearch();
+
+        assert.equal(doc.name, 'One', "Should use the default language for name key");
+        assert.equal(doc.name_en, 'One', "Should store language translations");
+        assert.equal(doc.name_es, 'Uno', "Should store language translations");
+
+        assert.equal(doc.foo[0].bar, 'Bar');
+        assert.equal(doc.foo[0].bar_en, 'Bar');
+        assert.equal(doc.foo[0].bar_es, 'Baro');
+        done();
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Rather than storing language objects in elasticsearch (which was what I did originally in #45) we simply flatten out any language objects so they take the form `{field_name}_{language_code}`, e.g. `name_en` or `name_en-gb`. This preserves backwards compatibility, so you can still do search queries like `name:Chris` and it will correctly return records who's name (in the default language) is Chris.
