### PR TITLE
Allow filtering fields returned by the API

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -14,6 +14,7 @@ function filter(doc, ret, options) {
   }
 
   var fields = options.fields || {};
+  var selectedFields = options.selectedFields || [];
 
   var newDoc = {};
 
@@ -37,6 +38,11 @@ function filter(doc, ret, options) {
 
     // Skip 'hidden' fields starting with an underscore.
     if (field.substr(0, 1) === '_') {
+      continue;
+    }
+
+    // If selectedFields is not empty, then skip any fields not mentioned in there.
+    if (selectedFields.length > 0 && selectedFields.indexOf(field) === -1) {
       continue;
     }
 

--- a/src/middleware/hidden-fields.js
+++ b/src/middleware/hidden-fields.js
@@ -36,6 +36,11 @@ function hiddenFields(req, res, next) {
   var schema = req.collection.schema;
   schema.options.toJSON.fields = fields;
 
+  schema.options.toJSON.selectedFields = [];
+  if (req.query.fields) {
+    schema.options.toJSON.selectedFields = req.query.fields.split(',');
+  }
+
   // Admin can see any fields.
   if (req.isAdmin) {
     return next();

--- a/test/rest.js
+++ b/test/rest.js
@@ -691,4 +691,30 @@ describe("REST", function () {
 
   });
 
+  describe("selecting fields", function() {
+    beforeEach(fixture.loadFixtures);
+
+    it("only returns the selected fields for collections", function(done) {
+      request.get('/api/persons?fields=id,name')
+      .expect(200)
+      .expect({
+        total: 2,
+        page: 1,
+        per_page: 30,
+        has_more: false,
+        result: [
+          { id: 'fred-bloggs', name: 'Fred Bloggs' },
+          { id: 'joe-bloggs', name: 'Joe Bloggs' }
+        ]
+      }, done);
+    });
+
+    it("only returns the selected fields on individual records", function(done) {
+      request.get('/api/persons/fred-bloggs?fields=id,name')
+      .expect(200)
+      .expect({result: {id: 'fred-bloggs', name: 'Fred Bloggs'}}, done);
+    });
+
+  });
+
 });


### PR DESCRIPTION
If the user only wants a subset of the fields that the API can return then they can use the '?fields' query string properties they want to be returned on objects.

Fixes https://github.com/mysociety/popit/issues/263
