### PR TITLE
Fix membership indexing issues

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -53,27 +53,34 @@ MembershipSchema.methods.toElasticsearch = function(callback) {
     if (err) {
       return callback(err);
     }
+    Person.schema.set('skipMemberships', true);
+    Organization.schema.set('skipMemberships', true);
+    Post.schema.set('skipMemberships', true);
     async.parallel({
       person: function(done) {
-        Person.findById(self.person_id, done);
+        Person.findById(self.person_id, {memberships: 0}, done);
       },
       organization: function(done) {
-        Organization.findById(self.organization_id, done);
+        Organization.findById(self.organization_id, {memberships: 0}, done);
       },
       post: function(done) {
-        Post.findById(self.post_id, done);
+        Post.findById(self.post_id, {memberships: 0}, done);
       },
       member: function(done) {
         if (!self.member) {
           return done();
         }
-        self.model(self.member['@type']).findById(self.member.id, done);
+        self.model(self.member['@type']).findById(self.member.id, {memberships: 0}, done);
       }
     }, function(err, results) {
       if (err) {
         return callback(err);
       }
       _.extend(doc, results);
+
+      Person.schema.set('skipMemberships', false);
+      Organization.schema.set('skipMemberships', false);
+      Post.schema.set('skipMemberships', false);
       callback(null, doc);
     });
   });

--- a/src/mongoose/membership-finder.js
+++ b/src/mongoose/membership-finder.js
@@ -21,6 +21,9 @@ function membershipFinder(schema, options) {
   }
 
   schema.pre('init', function(next, data) {
+    if (schema.get('skipMemberships')) {
+      return next();
+    }
     findMemberships(this.model('Membership'), this.constructor.modelName, data._id, function(err, docs) {
       if (err) {
         return next(err);


### PR DESCRIPTION
When indexing a large number of memberships the process was getting
killed with an out of memory error. This is because for each membership
the related person, post and organization was being looked up, then in turn
for each related person, post or organization their memberships were being
looked up.

This change skips indexing person, post and organization memberships
when embedding them in an indexed membership.

Without this change we can't reindex memberships, which prevents the changes from https://github.com/mysociety/popit-api/pull/46 going live.

Fixes https://github.com/mysociety/popit/issues/379
