### PR TITLE
Allow user to retrieve all translations for a record

### DIFF
--- a/src/mongoose/json-transform.js
+++ b/src/mongoose/json-transform.js
@@ -70,5 +70,8 @@ function filterDates(doc, ret, options) {
 }
 
 function translateDoc(doc, ret, options) {
+  if (options.returnAllTranslations) {
+    return ret;
+  }
   return i18n(ret, options.langs, options.defaultLanguage);
 }

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -87,6 +87,16 @@ describe("internationalization", function() {
         done();
       });
     });
+
+    it("returns all translations if requested", function(done) {
+      request.get('/api/persons/fred-bloggs/full')
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.deepEqual(res.body.result.name, {"ru":"Фред Влоггс","en":"Fred Bloggs"});
+        done();
+      });
+    });
   });
 
   describe("search", function() {


### PR DESCRIPTION
Previously there was no way to retrieve the whole record if it had
translations in it. This adds another API endpoint for retrieving the
"full" record complete with translation objects.

Fixes https://github.com/mysociety/popit/issues/382
