### PR TITLE
Set bulk index timeout to 5 minutes

### DIFF
--- a/src/mongoose/elasticsearch.js
+++ b/src/mongoose/elasticsearch.js
@@ -183,7 +183,9 @@ function elasticsearchPlugin(schema) {
         }
 
         // Send the commands and content docs to the bulk API.
-        client.bulk({body: body}, function(err) {
+        // Set the requestTimeout to 5 minutes to hopefully prevent timeouts
+        // for large collections.
+        client.bulk({body: body, requestTimeout: 300000}, function(err) {
           done(err, indexed);
         });
       });


### PR DESCRIPTION
When there is a large number of documents in an instance the bulk
reindexing sometimes fails because there is a timeout of 30 seconds, by
raising this to 5 minutes we will hopefully avoid this limit.

Fixes #57 
