### PR TITLE
Delete the elasticsearch index before reindexing

### DIFF
--- a/src/mongoose/elasticsearch.js
+++ b/src/mongoose/elasticsearch.js
@@ -198,4 +198,10 @@ function elasticsearchPlugin(schema) {
     });
 
   };
+
+  schema.statics.dropIndex = function dropIndex(done) {
+    client.indices.delete({
+      index: this.indexName()
+    }, done);
+  };
 }

--- a/src/reindex.js
+++ b/src/reindex.js
@@ -22,7 +22,12 @@ function reIndex(databaseName, callback) {
   var Post = connection.model('Post');
 
   async.mapSeries([Person, Organization, Membership, Post], function(Model, done) {
-    Model.reIndex(done);
+    Model.dropIndex(function(err) {
+      if (err) {
+        return done(err);
+      }
+      Model.reIndex(done);
+    });
   }, function(err, counts) {
     if (err) {
       return callback(err);


### PR DESCRIPTION
If we don't do this then there might be stray documents that are no longer in the database, so we get inconsistent results.

Fixes https://github.com/mysociety/popit/issues/592
Fixes https://github.com/mysociety/popit/issues/451
Fixes https://github.com/mysociety/popit/issues/416
