### PR TITLE
Enable collection GET requests on the API to populate memberships

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -40,6 +40,10 @@ function filter(doc, ret, options) {
       continue;
     }
 
+    if (field === 'memberships' && doc.schema.get('skipMemberships')) {
+      continue;
+    }
+
     // If we've made it this far then copy the field to the new doc.
     newDoc[field] = ret[field];
   }


### PR DESCRIPTION
This requests add /:collection/join/:join_specifier/:id syntax to the API to reduce the necessity for multiple requests when using information in the memberships of a collection item. It enables API requests with the persons or organizations of an items memberships populates, although not both at the same time.
