### PR TITLE
use req.popit for database name rather than deriving it from slug

### DIFF
--- a/src/middleware/storage-selector.js
+++ b/src/middleware/storage-selector.js
@@ -54,7 +54,7 @@ var storageSelectors = {
   popit: function(options) {
     return {
       selector: function(req, res, next) {
-        var databaseName = options.databasePrefix + req.subdomains[req.subdomains.length - 1];
+        var databaseName = options.databasePrefix + req.popit.dbname();
         req.db = connection(databaseName);
         next();
       },


### PR DESCRIPTION
if using the popit method to determine the database name then get the name of the database from the req.popit object as it's possible that the name of the database may not be the same as the slug now.
