### PR TITLE
Only include known parameters in pagination metadata

### DIFF
--- a/src/paginate.js
+++ b/src/paginate.js
@@ -40,6 +40,13 @@ function paginate(options) {
     if (currentUrl) {
       var parsedUrl = url.parse(currentUrl, true);
       delete parsedUrl.search;
+      var currentPerPage = parsedUrl.query.per_page;
+
+      parsedUrl.query = {};
+
+      if (currentPerPage) {
+        parsedUrl.query.per_page = currentPerPage;
+      }
 
       if (hasMore) {
         parsedUrl.query.page = (page + 1);

--- a/test/paginate.js
+++ b/test/paginate.js
@@ -77,5 +77,15 @@ describe("paginate", function() {
       assert.equal(metadata.prev_url, 'http://example.org/api/persons?page=1');
       assert(!metadata.next_url);
     });
+
+    it("doesn't include unknown parameters in next_url/prev_url", function() {
+      pagination = paginate({ page: 1 });
+      metadata = pagination.metadata(42, 'http://example.org/api/persons?callback=jQuery999');
+      assert.equal(metadata.next_url, 'http://example.org/api/persons?page=2');
+
+      pagination = paginate({ page: 2 });
+      metadata = pagination.metadata(42, 'http://example.org/api/persons?page=2&callback=jQuery999');
+      assert.equal(metadata.prev_url, 'http://example.org/api/persons?page=1');
+    });
   });
 });


### PR DESCRIPTION
Rather than including all parameters in the pagination metadata we just
include the `per_page` and `page` properties. This prevents problems
with jQuery's JSONP functionality where the 'callback' parameter was
being added to the url twice.

Fixes https://github.com/mysociety/popit-api/issues/69
