### PR TITLE
Match image dowload URL to API endpoint URL

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -515,6 +515,14 @@ function popitApiApp(options) {
     });
   });
 
+  // this doesn't make sense to do and we have to handle it
+  // explicitly otherwise documents with an id of :id/image
+  // are created which is almost certainly not what people
+  // want
+  app.put('/:collection/:id/image', function (req, res) {
+    res.status(405).jsonp({errors: ["unsupported method"] });
+  });
+
   function getImageByIdx( idx, images ) {
     for ( var i = 0; i < images.length; i++ ) {
       if ( images[i]._id == idx ) {

--- a/src/mongoose/json-transform.js
+++ b/src/mongoose/json-transform.js
@@ -81,9 +81,9 @@ function generateImageUrl(img, doc, options) {
   var url = [
     options.baseUrl,
     doc.constructor.collection.name.toLowerCase(),
-    'images',
-    img._id,
-    doc._id || doc.id
+    doc._id || doc.id,
+    'image',
+    img._id
   ].join('/');
 
   return url;


### PR DESCRIPTION
The UI used to use a different URL scheme for images which was different
from the endpoint used in the API but this has now been resolved so make
them match in the API output

For #84
