### PR TITLE
add in a search_dates end point

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -113,7 +113,9 @@ function popitApiApp(options) {
       });
 
       async.each(docs, function(doc, done) {
-        doc.populateMemberships(done);
+        doc.populateMemberships(function() {
+          doc.correctDates(done);
+        });
       }, function(err) {
         if (err) {
           return next(err);

--- a/src/esfilter.js
+++ b/src/esfilter.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var filter = require('./filter');
+
+module.exports = esFilter;
+
+function esFilter(doc, ret, options) {
+  if (!doc) {
+    return;
+  }
+
+  ret = filter(doc, ret, options);
+
+  for (var field in ret) {
+    if ( ['start_date', 'birth_date', 'founding_date'].indexOf(field) != -1 ) {
+      if (!ret[field]) {
+        var missing = field + '_missing';
+        ret[field] = '0000-01-01';
+        ret[missing] = true;
+      }
+    }
+
+    if( ['end_date', 'death_date', 'dissolution_date'].indexOf(field) != -1 ) {
+      if (!ret[field]) {
+        var missing = field + '_missing';
+        ret[field] = '9999-12-31';
+        ret[missing] = true;
+      }
+    }
+  }
+  return ret;
+}

--- a/src/models.js
+++ b/src/models.js
@@ -5,6 +5,7 @@ var popolo = require('./mongoose/popolo');
 var membershipFinder = require('./mongoose/membership-finder');
 var async = require('async');
 var _ = require('underscore');
+var esFilter = require('./esfilter');
 
 mongoose.set('debug', !!process.env.MONGOOSE_DEBUG);
 
@@ -49,19 +50,36 @@ MembershipSchema.methods.toElasticsearch = function(callback) {
   var Organization = this.model('Organization');
   var Post = this.model('Post');
   var self = this;
+
+  function applyToJSON(err, doc, done) {
+    if ( err ) {
+      done(err);
+    }
+
+    if (!doc) {
+      return done();
+    }
+
+    if (doc.toJSON) {
+      doc = doc.toJSON( { transform: esFilter });
+    }
+
+    done(null, doc);
+  }
+
   originalToElasticsearch.call(this, function(err, doc) {
     if (err) {
       return callback(err);
     }
     async.parallel({
       person: function(done) {
-        Person.findById(self.person_id, {memberships: 0}, done);
+        Person.findById(self.person_id, {memberships: 0}, function(err, doc) { applyToJSON(err, doc, done); });
       },
       organization: function(done) {
-        Organization.findById(self.organization_id, {memberships: 0}, done);
+        Organization.findById(self.organization_id, {memberships: 0}, function(err, doc) { applyToJSON(err, doc, done); });
       },
       post: function(done) {
-        Post.findById(self.post_id, {memberships: 0}, done);
+        Post.findById(self.post_id, {memberships: 0}, function(err, doc) { applyToJSON(err, doc, done); });
       },
       member: function(done) {
         if (!self.member) {

--- a/src/mongoose/elasticsearch.js
+++ b/src/mongoose/elasticsearch.js
@@ -11,6 +11,7 @@
 
 var elasticsearch = require('elasticsearch');
 var filter = require('../filter');
+var esFilter = require('../esfilter');
 var paginate = require('../paginate');
 var i18n = require('../i18n');
 var async = require('async');
@@ -43,7 +44,7 @@ function elasticsearchPlugin(schema) {
   schema.methods.toElasticsearch = function toElasticsearch(callback) {
     process.nextTick(function() {
       var doc = this.toJSON({
-        transform: filter,
+        transform: esFilter,
         fields: {
           all: {
             memberships: false,
@@ -73,6 +74,24 @@ function elasticsearchPlugin(schema) {
         callback(err);
       });
     });
+  };
+
+  /*
+   * Undo the date munging we do for search convenience.
+   */
+  schema.methods.correctDates = function correctDates(callback) {
+    callback = callback || function() {};
+    var self = this;
+
+    ['start_date', 'birth_date', 'founding_date','end_date', 'death_date', 'dissolution_date'].forEach(function(field) {
+      var missing = field + '_missing';
+      if ( self.get(missing) ) {
+        self.set(missing, undefined);
+        self.set(field, undefined);
+      }
+    });
+
+    callback();
   };
 
   /**


### PR DESCRIPTION
We do this so we can add in the correct handling of empty dates to the
elastic search query. people could do this themselves but this means
they don't need to worry about the exact syntax.

Adds an end point of the form:

```
/api/v0.1/search_dates/:collection?q=Barnaby&birth_date:>1970-01-01
```

Fixes #63
