### PR TITLE
fix elastic search date mapping and search issues

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -113,7 +113,9 @@ function popitApiApp(options) {
       });
 
       async.each(docs, function(doc, done) {
-        doc.populateMemberships(done);
+        doc.populateMemberships(function() {
+          doc.correctDates(done);
+        });
       }, function(err) {
         if (err) {
           return next(err);

--- a/src/esfilter.js
+++ b/src/esfilter.js
@@ -1,0 +1,73 @@
+"use strict";
+
+var _ = require('underscore');
+var filter = require('./filter');
+
+
+module.exports = function esFilters() {
+  return {
+    esFilter: function esFilter(doc, ret, options) {
+      if (!doc) {
+        return;
+      }
+
+      ret = filter(doc, ret, options);
+
+      return esFilterDatesOnly(doc, ret, options);
+    },
+
+    esFilterDatesOnly: esFilterDatesOnly,
+  };
+
+  function transformImages(image) {
+    // the default format images use makes automapping in Elastic Search
+    // unhappy so change it to something ES can parse
+    if (image.created && image.created.toISOString ) {
+      image.created = image.created.toISOString();
+    }
+    // don't save the mongo ObjectID, save the id
+    if (image._id && image._id.toString) {
+      image._id = image._id.toString();
+    }
+
+    return image;
+  }
+
+  function esFilterDatesOnly(doc, ret) {
+    var missing = '';
+    for (var field in ret) {
+      if ( ['start_date', 'birth_date', 'founding_date', 'created_at', 'updated_at', 'valid_from'].indexOf(field) != -1 ) {
+        if (!ret[field]) {
+          missing = field + '_missing';
+          ret[field] = '0000-01-01';
+          ret[missing] = true;
+        }
+      }
+
+      if ( ['end_date', 'death_date', 'dissolution_date', 'valid_until'].indexOf(field) != -1 ) {
+        if (!ret[field]) {
+          missing = field + '_missing';
+          ret[field] = '9999-12-31';
+          ret[missing] = true;
+        }
+      }
+
+      // these also contain dates so we need to process them
+      if ( field == 'contact_details' || field == 'other_names' ) {
+        ret[field] = esFilterDatesOnly(ret[field], ret[field]);
+      }
+
+      if ( field == 'images' && _.isArray(ret.images) && ret.images.length > 0 ) {
+        var images = ret.images;
+        var new_images = images.map(transformImages);
+
+        if ( new_images.length ) {
+          ret.images = new_images;
+        } else {
+          ret.images = undefined;
+        }
+      }
+    }
+    return ret;
+  }
+};


### PR DESCRIPTION
Elastic search isn't happy with saving blank dates so we put in some
place holder ones and mark them as such when indexing documents. We then
remove the place holders and markers when we pull the dates back out.

This also means that death_date:>$some_date etc works as expected when
using the search.

FIxes #63 and Fixes mysociety/popit#610
