### PR TITLE
Use embed parameter on collections and search endpoints

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -113,7 +113,7 @@ function popitApiApp(options) {
       });
 
       async.each(docs, function(doc, done) {
-        doc.populateMemberships(function() {
+        doc.embedDocuments(req.query.embed, function() {
           doc.correctDates(done);
         });
       }, function(err) {
@@ -136,7 +136,7 @@ function popitApiApp(options) {
       }
 
       async.each(docs, function(doc, done) {
-        doc.populateMemberships(done);
+        doc.embedDocuments(req.query.embed, done);
       }, function(err) {
         if (err) {
           return next(err);


### PR DESCRIPTION
Switch to using the `embedDocuments` method, which in turn calls `populateMemberships` but respects the `?embed` parameter.

Fixes https://github.com/mysociety/popit-api/issues/91
Fixes https://github.com/mysociety/popit/issues/682
