### PR TITLE
make sure memberships going into ES are translated

### DIFF
--- a/src/esfilter.js
+++ b/src/esfilter.js
@@ -2,7 +2,7 @@
 
 var _ = require('underscore');
 var filter = require('./filter');
-
+var translate = require('./mongoose/json-transform').translateDoc;
 
 module.exports = function esFilters() {
   return {
@@ -16,7 +16,18 @@ module.exports = function esFilters() {
       return esFilterDatesOnly(doc, ret, options);
     },
 
-    esFilterDatesOnly: esFilterDatesOnly,
+    esTranslateFilter: function esTranslateFilter(doc, ret, options) {
+      if (!doc) {
+        return;
+      }
+
+      //converts _id -> id in organization which upsets test
+      ret = filter(doc, ret, options);
+      ret = translate(doc, ret, options);
+      ret = esFilterDatesOnly(doc, ret, options);
+
+      return ret;
+    }
   };
 
   function transformImages(image) {

--- a/src/mongoose/json-transform.js
+++ b/src/mongoose/json-transform.js
@@ -3,7 +3,8 @@
 var filter = require('../filter');
 var i18n = require('../i18n');
 
-module.exports = jsonTransformPlugin;
+module.exports.jsonTransformPlugin = jsonTransformPlugin;
+module.exports.translateDoc = translateDoc;
 
 function jsonTransformPlugin(schema) {
   schema.set('toJSON', {transform: filterFields});
@@ -74,7 +75,7 @@ function translateDoc(doc, ret, options) {
   if (options.returnAllTranslations) {
     return ret;
   }
-  return i18n(ret, options.langs, options.defaultLanguage);
+  return i18n(ret, options.langs, options.defaultLanguage, options.includeTranslations);
 }
 
 function generateImageUrl(img, doc, options) {

--- a/src/mongoose/popolo.js
+++ b/src/mongoose/popolo.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var mongooseJsonSchema = require('./json-schema');
-var jsonTransform = require('./json-transform');
+var jsonTransform = require('./json-transform').jsonTransformPlugin;
 var search = require('./search');
 var elasticsearch = require('./elasticsearch');
 var embed = require('./embed');

--- a/test/memberships.js
+++ b/test/memberships.js
@@ -74,9 +74,9 @@ describe("memberships", function() {
         assert.ifError(err);
         membership.toElasticsearch(function(err, result) {
           assert.ifError(err);
-          assert.equal(result.organization._id, 'foo-widgets');
+          assert.equal(result.organization.id, 'foo-widgets');
           assert.equal(result.organization.name, 'Foo Widgets');
-          assert.equal(result.member._id, 'joe-bloggs');
+          assert.equal(result.member.id, 'joe-bloggs');
           assert.equal(result.member.name, 'Joe Bloggs');
           done();
         });


### PR DESCRIPTION
Pass the memberships plus the inflated documents contained within them
through translation on the way into ES. As part of this we now convert
_id to id on memberships going into ES but this makes them consistent
with everything else.
