### PR TITLE
Create/update memberships included inline in documents

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -361,12 +361,7 @@ function popitApiApp(options) {
 
   function removeMemberships(memberships, callback) {
     async.each(memberships, function deleteMembership(membership, done) {
-      membership.remove(function(err) {
-        if (err) {
-          return done(err);
-        }
-        done();
-      });
+      membership.remove(done);
     }, function (err) {
       callback(err);
     });

--- a/src/app.js
+++ b/src/app.js
@@ -424,6 +424,12 @@ function popitApiApp(options) {
       } else if ( membership.organization_id != doc.id ) {
         return done("organization id (" + membership.organization_id + ") in membership and organization id (" + doc.id + ") are mismatched");
       }
+    } else if ( req.model.modelName == 'Post' ) {
+      if ( !membership.post_id ) {
+        membership.post_id = doc.id;
+      } else if ( membership.post_id != doc.id ) {
+        return done("post id (" + membership.post_id + ") in membership and post id (" + doc.id + ") are mismatched");
+      }
     }
     return done(null, membership);
   }

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var express = require('express');
-var _ = require('underscore');
 var mongoose = require('mongoose');
 var packageJSON = require("../package");
 var path = require('path');
@@ -25,6 +24,10 @@ var InvalidQueryError = require('./mongoose/elasticsearch').InvalidQueryError;
 var async = require('async');
 var InvalidEmbedError = require('./mongoose/embed').InvalidEmbedError;
 var MergeConflictError = require('./mongoose/merge').MergeConflictError;
+
+var tidyUpInlineMembershipError = require('./inline-memberships').tidyUpInlineMembershipError;
+var processMembership = require('./inline-memberships').processMembership;
+var removeOldMemberships = require('./inline-memberships').removeOldMemberships;
 
 module.exports = popitApiApp;
 
@@ -359,144 +362,6 @@ function popitApiApp(options) {
     });
   });
 
-  function removeMemberships(memberships, callback) {
-    async.each(memberships, function deleteMembership(membership, done) {
-      membership.remove(done);
-    }, function (err) {
-      callback(err);
-    });
-  }
-
-  function restoreMemberships(req, memberships, callback) {
-    var Membership = req.db.model(models.memberships.modelName);
-    async.each(memberships, function restoreMembership(membership, done) {
-      Membership.findById(membership.id, function(err, mem) {
-        if (mem) {
-          mem.set(membership);
-          mem.save(function(err) {
-            if (err) {
-              return done(err);
-            }
-            return done();
-          });
-        } else {
-          membership._id = membership.id;
-          Membership.create(membership, function (err, mem) {
-            if ( err ) {
-              return done(err);
-            }
-            done(null, mem);
-          });
-        }
-      });
-    }, function (err) {
-      callback(err);
-    });
-  }
-
-  function tidyUpInlineMembershipError(req, doc, created, updated, callback) {
-    if (doc) {
-      doc.remove(function(err) {
-        if (err) {
-          return callback(err);
-        }
-        removeMemberships(created, callback);
-      });
-    } else {
-      removeMemberships(created, function (err) {
-        if (err) {
-          return callback(err);
-        }
-        restoreMemberships(req, updated, callback);
-      });
-    }
-  }
-
-  function checkMembership(req, membership, doc, done) {
-    if ( req.model.modelName == 'Person' ) {
-      if ( !membership.person_id ) {
-        membership.person_id = doc.id;
-      } else if ( membership.person_id != doc.id ) {
-        return done("person id (" + membership.person_id + ") in membership and person id (" + doc.id + ") are mismatched");
-      }
-    } else if ( req.model.modelName == 'Organization' ) {
-      if ( !membership.organization_id ) {
-        membership.organization_id = doc.id;
-      } else if ( membership.organization_id != doc.id ) {
-        return done("organization id (" + membership.organization_id + ") in membership and organization id (" + doc.id + ") are mismatched");
-      }
-    } else if ( req.model.modelName == 'Post' ) {
-      if ( !membership.post_id ) {
-        membership.post_id = doc.id;
-      } else if ( membership.post_id != doc.id ) {
-        return done("post id (" + membership.post_id + ") in membership and post id (" + doc.id + ") are mismatched");
-      }
-    }
-    return done(null, membership);
-  }
-
-  function createMembership(req, membership, done) {
-    if ( !membership.id ) {
-      var id = new mongoose.Types.ObjectId();
-      membership.id = id.toHexString();
-    }
-    membership._id = membership.id;
-    var Membership = req.db.model(models.memberships.modelName);
-    Membership.create(membership, function (err, mem) {
-      if ( err ) {
-        return done(err);
-      }
-      done(null, mem);
-    });
-  }
-
-  function processMembership(membership, req, doc, done) {
-    var existing = false;
-    var Membership = req.db.model(models.memberships.modelName);
-    async.waterfall([
-      function callCheckMembership(cb) {
-        checkMembership(req, membership, doc, cb);
-      },
-      function callCreateMembership(membership, cb) {
-        if ( ! membership.id ) {
-          createMembership(req, membership, function(err, membership) {
-            if ( err ) {
-              return cb(err);
-            }
-            req.created_memberships.push(membership);
-            cb();
-          });
-        } else {
-          Membership.findById(membership.id, function(err, mem) {
-            if (mem) {
-              existing = true;
-              req.updated_memberships.push(mem.toJSON());
-              mem.set(membership);
-              mem.save(function(err) {
-                if (err) {
-                  return cb(err);
-                }
-                return cb();
-              });
-            } else {
-              createMembership(req, membership, function(err, membership) {
-                if ( err ) {
-                  return cb(err);
-                }
-                req.created_memberships.push(membership);
-                cb();
-              });
-            }
-          });
-        }
-      }], function membershipCreated(err) {
-        if (err) {
-          return done(err);
-        }
-        done();
-      });
-  }
-
   app.post('/:collection', validateBody, function (req, res, next) {
     var body = req.body;
     // if there's an image and no body.images then add one as the popit front end uses
@@ -732,36 +597,6 @@ function popitApiApp(options) {
       saveImages( doc, image, upload, dest_path, res, next, imageIdx );
     });
   });
-
-  function removeOldMemberships(req, memberships, key, id, done) {
-    var membership_ids =
-      _.chain(memberships)
-       .map( function(membership) { return membership.id; })
-       .compact()
-       .value();
-
-    var Membership = req.db.model(models.memberships.modelName);
-    var criteria = {};
-    criteria[key] = id;
-    var removed = [];
-    Membership
-      .find( criteria )
-      .where( '_id' ).nin( membership_ids )
-      .exec( function( err, memberships ) {
-        if ( err ) {
-          return done(err);
-        }
-        async.forEachSeries(memberships, function(membership, done) {
-          removed.push(membership.toJSON());
-          membership.remove(done);
-        }, function (err) {
-          if (err) {
-            return done(err);
-          }
-          done(null, removed);
-        });
-      });
-  }
 
   app.put('/:collection/:id(*)', validateBody, function (req, res, next) {
 

--- a/src/app.js
+++ b/src/app.js
@@ -825,7 +825,13 @@ function popitApiApp(options) {
             });
         }, function afterCreateMemberships(err) {
           if (err) {
-            next(err);
+            tidyUpInlineMembershipError(req, null, created_memberships, updated_memberships, function(innerErr) {
+              if ( innerErr ) {
+                return res.send(400, {errors: [innerErr]});
+              }
+              return res.send(400, {errors: [err]});
+            });
+            return;
           }
           // TODO: need to store these and restore them in the
           // event of badness

--- a/src/app.js
+++ b/src/app.js
@@ -465,7 +465,10 @@ function popitApiApp(options) {
         return next(err);
       }
       if ( memberships ) {
-        async.each(memberships, function processMembership(membership, done) {
+        // we do this in series otherwise if there's an error we might not
+        // have recorded all the memberships created and hence can't
+        // undo things correctly
+        async.eachSeries(memberships, function processMembership(membership, done) {
           async.waterfall([
             function callCheckMembership(cb) {
               checkMembership(req, membership, doc, cb);
@@ -773,7 +776,10 @@ function popitApiApp(options) {
       delete body.memberships;
       if ( memberships ) {
         var Membership = req.db.model(models.memberships.modelName);
-        async.each(memberships, function processMembership(membership, done) {
+        // we do this in series otherwise if there's an error we might not
+        // have recorded all the memberships created/updated and hence can't
+        // undo things correctly
+        async.eachSeries(memberships, function processMembership(membership, done) {
           var existing = false;
           async.waterfall([
             function callCheckMembership(cb) {

--- a/src/inline-memberships.js
+++ b/src/inline-memberships.js
@@ -1,0 +1,178 @@
+"use strict";
+
+var _ = require('underscore');
+var mongoose = require('mongoose');
+var models = require('./models');
+var async = require('async');
+
+function removeMemberships(memberships, callback) {
+  async.each(memberships, function deleteMembership(membership, done) {
+    membership.remove(done);
+  }, function (err) {
+    callback(err);
+  });
+}
+
+function restoreMemberships(req, memberships, callback) {
+  var Membership = req.db.model(models.memberships.modelName);
+  async.each(memberships, function restoreMembership(membership, done) {
+    Membership.findById(membership.id, function(err, mem) {
+      if (mem) {
+        mem.set(membership);
+        mem.save(function(err) {
+          if (err) {
+            return done(err);
+          }
+          return done();
+        });
+      } else {
+        membership._id = membership.id;
+        Membership.create(membership, function (err, mem) {
+          if ( err ) {
+            return done(err);
+          }
+          done(null, mem);
+        });
+      }
+    });
+  }, function (err) {
+    callback(err);
+  });
+}
+
+function tidyUpInlineMembershipError(req, doc, created, updated, callback) {
+  if (doc) {
+    doc.remove(function(err) {
+      if (err) {
+        return callback(err);
+      }
+      removeMemberships(created, callback);
+    });
+  } else {
+    removeMemberships(created, function (err) {
+      if (err) {
+        return callback(err);
+      }
+      restoreMemberships(req, updated, callback);
+    });
+  }
+}
+
+function checkMembership(req, membership, doc, done) {
+  if ( req.model.modelName == 'Person' ) {
+    if ( !membership.person_id ) {
+      membership.person_id = doc.id;
+    } else if ( membership.person_id != doc.id ) {
+      return done("person id (" + membership.person_id + ") in membership and person id (" + doc.id + ") are mismatched");
+    }
+  } else if ( req.model.modelName == 'Organization' ) {
+    if ( !membership.organization_id ) {
+      membership.organization_id = doc.id;
+    } else if ( membership.organization_id != doc.id ) {
+      return done("organization id (" + membership.organization_id + ") in membership and organization id (" + doc.id + ") are mismatched");
+    }
+  } else if ( req.model.modelName == 'Post' ) {
+    if ( !membership.post_id ) {
+      membership.post_id = doc.id;
+    } else if ( membership.post_id != doc.id ) {
+      return done("post id (" + membership.post_id + ") in membership and post id (" + doc.id + ") are mismatched");
+    }
+  }
+  return done(null, membership);
+}
+
+function createMembership(req, membership, done) {
+  if ( !membership.id ) {
+    var id = new mongoose.Types.ObjectId();
+    membership.id = id.toHexString();
+  }
+  membership._id = membership.id;
+  var Membership = req.db.model(models.memberships.modelName);
+  Membership.create(membership, function (err, mem) {
+    if ( err ) {
+      return done(err);
+    }
+    done(null, mem);
+  });
+}
+
+function processMembership(membership, req, doc, done) {
+  var existing = false;
+  var Membership = req.db.model(models.memberships.modelName);
+  async.waterfall([
+    function callCheckMembership(cb) {
+      checkMembership(req, membership, doc, cb);
+    },
+    function callCreateMembership(membership, cb) {
+      if ( ! membership.id ) {
+        createMembership(req, membership, function(err, membership) {
+          if ( err ) {
+            return cb(err);
+          }
+          req.created_memberships.push(membership);
+          cb();
+        });
+      } else {
+        Membership.findById(membership.id, function(err, mem) {
+          if (mem) {
+            existing = true;
+            req.updated_memberships.push(mem.toJSON());
+            mem.set(membership);
+            mem.save(function(err) {
+              if (err) {
+                return cb(err);
+              }
+              return cb();
+            });
+          } else {
+            createMembership(req, membership, function(err, membership) {
+              if ( err ) {
+                return cb(err);
+              }
+              req.created_memberships.push(membership);
+              cb();
+            });
+          }
+        });
+      }
+    }], function membershipCreated(err) {
+      if (err) {
+        return done(err);
+      }
+      done();
+    });
+}
+
+function removeOldMemberships(req, memberships, key, id, done) {
+  var membership_ids =
+    _.chain(memberships)
+     .map( function(membership) { return membership.id; })
+     .compact()
+     .value();
+
+  var Membership = req.db.model(models.memberships.modelName);
+  var criteria = {};
+  criteria[key] = id;
+  var removed = [];
+  Membership
+    .find( criteria )
+    .where( '_id' ).nin( membership_ids )
+    .exec( function( err, memberships ) {
+      if ( err ) {
+        return done(err);
+      }
+      async.forEachSeries(memberships, function(membership, done) {
+        removed.push(membership.toJSON());
+        membership.remove(done);
+      }, function (err) {
+        if (err) {
+          return done(err);
+        }
+        done(null, removed);
+      });
+    });
+}
+
+module.exports.tidyUpInlineMembershipError = tidyUpInlineMembershipError;
+module.exports.processMembership = processMembership;
+module.exports.removeOldMemberships = removeOldMemberships;

--- a/test/rest.js
+++ b/test/rest.js
@@ -788,6 +788,28 @@ describe("REST", function () {
       });
     });
 
+    it("creates memberships included in an organizations POST", function(done) {
+      request.post('/api/organizations')
+      .send({id: 'new-org', name: 'New Org', memberships: [ { person_id: "bob-example", organization_id: 'new-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        done();
+      });
+    });
+
+    it("creates memberships included in an post POST", function(done) {
+      request.post('/api/posts')
+      .send({id: 'new-post', label: 'New Post', memberships: [ { post_id: "new-post", organization_id: 'new-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        done();
+      });
+    });
+
     it("adds the id of the created object to the membership if missing", function(done) {
       request.post('/api/persons')
       .send({id: 'bob-example', name: 'Bob Example', memberships: [ { organization_id: 'example-org' } ]})
@@ -796,6 +818,30 @@ describe("REST", function () {
         assert.ifError(err);
         assert.equal(res.body.result.memberships.length, 1);
         assert.equal(res.body.result.memberships[0].person_id, 'bob-example');
+        done();
+      });
+    });
+
+    it("it adds the id of the created org to the membership is missing in a POST", function(done) {
+      request.post('/api/organizations')
+      .send({id: 'new-org', name: 'New Org', memberships: [ { person_id: "bob-example" } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        assert.equal(res.body.result.memberships[0].organization_id, 'new-org');
+        done();
+      });
+    });
+
+    it("it adds the id of the created post to the membership is missing in a POST", function(done) {
+      request.post('/api/posts')
+      .send({id: 'new-post', label: 'New Post', memberships: [ { organization_id: 'new-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        assert.equal(res.body.result.memberships[0].post_id, 'new-post');
         done();
       });
     });
@@ -818,6 +864,51 @@ describe("REST", function () {
       });
     });
 
+    it("returns error and doesn't create anything if you try and create a membership for a different post", function(done) {
+      request.post('/api/posts')
+      .send({id: 'new-post', label: 'New Post', memberships: [ { post_id: 'other-post', organization_id: 'new-org' } ]})
+      .expect(400)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.errors.length, 1);
+        assert.equal(res.body.errors[0], "post id (other-post) in membership and post id (new-post) are mismatched");
+
+        request.get('/api/posts/new-post')
+        .expect(404)
+        .end(function(err) {
+          assert.ifError(err);
+          done();
+        });
+      });
+    });
+
+    it("returns error and doesn't create anything if you try and create several memberships for a different doc", function(done) {
+      request.post('/api/persons')
+      .send({id: 'bob-example', name: 'Bob Example', memberships: [
+        { person_id: 'bob-example', organization_id: 'example-org' },
+        { person_id: 'dave-example', organization_id: 'example-org' }
+      ]})
+      .expect(400)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.errors.length, 1);
+        assert.equal(res.body.errors[0], "person id (dave-example) in membership and person id (bob-example) are mismatched");
+
+        request.get('/api/persons/bob-example')
+        .expect(404)
+        .end(function(err) {
+          assert.ifError(err);
+          request.get('/api/memberships')
+            .expect(200)
+            .end(function(err, res) {
+              assert.ifError(err);
+              assert.equal(res.body.total, 2);
+              done();
+          });
+        });
+      });
+    });
+
     it("creates memberships included in PUT", function(done) {
       request.put('/api/persons/joe-bloggs')
       .send({name: 'Joe Bloggs', memberships: [ { person_id: "joe-bloggs", organization_id: 'example-org' } ]})
@@ -825,6 +916,53 @@ describe("REST", function () {
       .end(function(err, res) {
         assert.ifError(err);
         assert.equal(res.body.result.memberships.length, 1);
+        done();
+      });
+    });
+
+    it("creates memberships included in an organizations PUT", function(done) {
+      request.put('/api/organizations/parliament')
+      .send({name: 'Houses of Parliament', memberships: [ { person_id: "joe-bloggs", organization_id: 'parliament' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        done();
+      });
+    });
+
+    it("creates memberships included in an post POST", function(done) {
+      request.put('/api/posts/annapolis')
+      .send({ label: 'MP for Annapolis', memberships: [ { post_id: "annapolis", organization_id: 'new-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        assert.equal(res.body.result.memberships[0].organization_id, 'new-org');
+        done();
+      });
+    });
+
+    it("adds current person_id if missing from memberships included in PUT", function(done) {
+      request.put('/api/persons/joe-bloggs')
+      .send({name: 'Joe Bloggs', memberships: [ { organization_id: 'example-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        assert.equal(res.body.result.memberships[0].person_id, 'joe-bloggs');
+        done();
+      });
+    });
+
+    it("adds current organization_id if missing from memberships included in PUT", function(done) {
+      request.put('/api/organizations/parliament')
+      .send({name: 'Houses of Parliament', memberships: [ { person_id: 'joe-bloggs' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        assert.equal(res.body.result.memberships[0].organization_id, 'parliament');
         done();
       });
     });
@@ -845,6 +983,237 @@ describe("REST", function () {
           assert.equal(res.body.result.memberships.length, 1);
           assert.notEqual(res.body.result.memberships[0].id, mem_id);
           done();
+        });
+      });
+    });
+
+    it("removes all memberships if none included in a PUT", function(done) {
+      request.put('/api/persons/joe-bloggs')
+      .send({name: 'Joe Bloggs', memberships: [ { person_id: "joe-bloggs", organization_id: 'example-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        request.put('/api/persons/joe-bloggs')
+        .send({name: 'Joe Bloggs', memberships: [ ]})
+        .expect(200)
+        .end(function(err, res) {
+          assert.ifError(err);
+          assert.equal(res.body.result.memberships.length, 0);
+          done();
+        });
+      });
+    });
+
+    it("memberships are unchanged if no membership key in a PUT", function(done) {
+      request.put('/api/persons/joe-bloggs')
+      .send({name: 'Joe Bloggs', memberships: [ { person_id: "joe-bloggs", organization_id: 'example-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        var mem_id = res.body.result.memberships[0].id;
+        request.put('/api/persons/joe-bloggs')
+        .send({name: 'Joe Bloggs' })
+        .expect(200)
+        .end(function(err, res) {
+          assert.ifError(err);
+          assert.equal(res.body.result.memberships.length, 0);
+          request.get('/api/persons/joe-bloggs?embed=membership')
+            .expect(200)
+            .end(function(err, res) {
+              assert.ifError(err);
+              assert.equal(res.body.result.memberships.length, 1);
+              assert.equal(res.body.result.memberships[0].id, mem_id);
+              done();
+          });
+        });
+      });
+    });
+
+    it("updates existing memberships included in a PUT", function(done) {
+      request.put('/api/persons/joe-bloggs')
+      .send({name: 'Joe Bloggs', memberships: [ { person_id: "joe-bloggs", organization_id: 'example-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        var mem_id = res.body.result.memberships[0].id;
+        request.put('/api/persons/joe-bloggs')
+        .send({name: 'Joe Bloggs', memberships: [ { id: mem_id, person_id: "joe-bloggs", organization_id: 'another-org' } ]})
+        .expect(200)
+        .end(function(err, res) {
+          assert.ifError(err);
+          assert.equal(res.body.result.memberships.length, 1);
+          assert.equal(res.body.result.memberships[0].organization_id, 'another-org');
+          done();
+        });
+      });
+    });
+
+    it("returns error if person_id mismatched in PUT", function(done) {
+      request.put('/api/persons/joe-bloggs')
+      .send({name: 'Joe Bloggs', memberships: [ { person_id: "james-bloggs", organization_id: 'example-org' } ]})
+      .expect(400)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.errors[0], "person id (james-bloggs) in membership and person id (joe-bloggs) are mismatched");
+        done();
+      });
+    });
+
+    it("returns error if organization_id mismatched in PUT", function(done) {
+      request.put('/api/organizations/parliament')
+      .send({name: 'Houses of Parliament', memberships: [ { person_id: "joe-bloggs", organization_id: 'example-org' } ]})
+      .expect(400)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.errors[0], "organization id (example-org) in membership and organization id (parliament) are mismatched");
+        done();
+      });
+    });
+
+    it("deletes memberships created if error in PUT", function(done) {
+      request.put('/api/persons/joe-bloggs')
+      .send({name: 'Joe Bloggs', memberships: [
+        { person_id: "joe-bloggs", organization_id: 'example-org' },
+        { person_id: "james-bloggs", organization_id: 'example-org' }
+      ]})
+      .expect(400)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.errors[0], "person id (james-bloggs) in membership and person id (joe-bloggs) are mismatched");
+        request.get('/api/persons/joe-bloggs?embed=membership')
+          .expect(200)
+          .end(function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.body.result.memberships.length, 0);
+            done();
+        });
+      });
+    });
+
+    it("deletes memberships created if error in organization PUT", function(done) {
+      request.put('/api/organizations/parliament')
+      .send({name: 'Houses of Parliament', memberships: [
+        { person_id: "joe-bloggs", organization_id: 'parliament' },
+        { person_id: "joe-bloggs", organization_id: 'example-org' }
+      ]})
+      .expect(400)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.errors[0], "organization id (example-org) in membership and organization id (parliament) are mismatched");
+        request.get('/api/organizations/parliament?embed=membership')
+          .expect(200)
+          .end(function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.body.result.memberships.length, 0);
+            done();
+        });
+      });
+    });
+
+    it("restores existing memberships if there's an error in a PUT", function(done) {
+      request.put('/api/persons/joe-bloggs')
+      .send({name: 'Joe Bloggs', memberships: [{ person_id: "joe-bloggs", organization_id: 'example-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        var mem_id = res.body.result.memberships[0].id;
+        request.put('/api/persons/joe-bloggs')
+        .send({name: 'Joe Bloggs', memberships: [
+          { id: mem_id, person_id: "joe-bloggs", organization_id: 'another-org' },
+          { person_id: "james-bloggs", organization_id: 'example-org' }
+        ]})
+        .expect(400)
+        .end(function(err, res) {
+          assert.ifError(err);
+          assert.equal(res.body.errors[0], "person id (james-bloggs) in membership and person id (joe-bloggs) are mismatched");
+          request.get('/api/persons/joe-bloggs?embed=membership')
+            .expect(200)
+            .end(function(err, res) {
+              assert.ifError(err);
+              assert.equal(res.body.result.memberships.length, 1);
+              assert.equal(res.body.result.memberships[0].id, mem_id);
+              assert.equal(res.body.result.memberships[0].organization_id, 'example-org');
+              done();
+          });
+        });
+      });
+    });
+
+    it("restores deleted memberships if there's an error in a PUT", function(done) {
+      request.put('/api/persons/joe-bloggs')
+      .send({name: 'Joe Bloggs', memberships: [{ person_id: "joe-bloggs", organization_id: 'example-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        var mem_id = res.body.result.memberships[0].id;
+        request.put('/api/persons/joe-bloggs')
+        .send({name: 'Joe Bloggs', memberships: [
+          { person_id: "james-bloggs", organization_id: 'example-org' }
+        ]})
+        .expect(400)
+        .end(function(err, res) {
+          assert.ifError(err);
+          assert.equal(res.body.errors[0], "person id (james-bloggs) in membership and person id (joe-bloggs) are mismatched");
+          request.get('/api/persons/joe-bloggs?embed=membership')
+            .expect(200)
+            .end(function(err, res) {
+              assert.ifError(err);
+              assert.equal(res.body.result.memberships.length, 1);
+              assert.equal(res.body.result.memberships[0].id, mem_id);
+              assert.equal(res.body.result.memberships[0].organization_id, 'example-org');
+              done();
+          });
+        });
+      });
+    });
+
+    it("restores existing document if there's an error in a PUT", function(done) {
+      request.put('/api/persons/joe-bloggs')
+      .send({name: 'Joe Bloggs', memberships: [{ person_id: "joe-bloggs", organization_id: 'example-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        request.put('/api/persons/joe-bloggs')
+        .send({name: 'James Bloggs', memberships: [
+          { person_id: "james-bloggs", organization_id: 'example-org' }
+        ]})
+        .expect(400)
+        .end(function(err, res) {
+          assert.ifError(err);
+          assert.equal(res.body.errors[0], "person id (james-bloggs) in membership and person id (joe-bloggs) are mismatched");
+          request.get('/api/persons/joe-bloggs')
+            .expect(200)
+            .end(function(err, res) {
+              assert.ifError(err);
+              done();
+              assert.equal(res.body.result.name, 'Joe Bloggs');
+          });
+        });
+      });
+    });
+
+    it("restores existing organization if there's an error in a PUT", function(done) {
+      request.put('/api/organizations/parliament')
+      .send({name: 'The Houses of Parliament', memberships: [
+        { person_id: "joe-bloggs", organization_id: 'parliament' },
+        { person_id: "joe-bloggs", organization_id: 'example-org' }
+      ]})
+      .expect(400)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.errors[0], "organization id (example-org) in membership and organization id (parliament) are mismatched");
+        request.get('/api/organizations/parliament')
+          .expect(200)
+          .end(function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.body.result.name, 'Houses of Parliament');
+            done();
         });
       });
     });

--- a/test/rest.js
+++ b/test/rest.js
@@ -811,8 +811,39 @@ describe("REST", function () {
 
         request.get('/api/persons/bob-example')
         .expect(404)
+        .end(function(err) {
+          assert.ifError(err);
+          done();
+        });
+      });
+    });
+
+    it("creates memberships included in PUT", function(done) {
+      request.put('/api/persons/joe-bloggs')
+      .send({name: 'Joe Bloggs', memberships: [ { person_id: "joe-bloggs", organization_id: 'example-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        done();
+      });
+    });
+
+    it("removes memberships not included in a PUT", function(done) {
+      request.put('/api/persons/joe-bloggs')
+      .send({name: 'Joe Bloggs', memberships: [ { person_id: "joe-bloggs", organization_id: 'example-org' } ]})
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships.length, 1);
+        var mem_id = res.body.result.memberships[0].id;
+        request.put('/api/persons/joe-bloggs')
+        .send({name: 'Joe Bloggs', memberships: [ { person_id: "joe-bloggs", organization_id: 'another-org' } ]})
+        .expect(200)
         .end(function(err, res) {
           assert.ifError(err);
+          assert.equal(res.body.result.memberships.length, 1);
+          assert.notEqual(res.body.result.memberships[0].id, mem_id);
           done();
         });
       });


### PR DESCRIPTION
This changes the API to process memberships included in POSTs and PUTs which create or update persons, organizations or posts. If a membership key is included in these then the memberships of the document will be updated to match this. It will create, update and delete memberships as required in order to do this.

If no memberships key is present in the document them memberships will be unchanged.