### PR TITLE
Popolo export

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -697,6 +697,17 @@ function popitApiApp(options) {
 
   });
 
+  // Error handling
+  app.use(function(err, req, res, next) {
+    // This should always be an error, but jshint complains if we don't use all
+    // arguments and express will only interpret this as an error handler if
+    // the arity is 4.
+    if (!err) {
+      return next();
+    }
+    console.error(err.stack);
+    res.status(500).send({errors: ["Something went wrong", err.message]});
+  });
 
   /*
     Anything else we should 400 for as it is probably an unsupported method.

--- a/src/app.js
+++ b/src/app.js
@@ -79,12 +79,19 @@ function popitApiApp(options) {
     });
   });
 
+  // Export all languages - can potentially produce invalid popolo
   app.get('/export.json', function(req, res, next) {
     exporter(req.db, function(err, exportObject) {
       if (err) {
         return next(err);
       }
+      eachSchema(req.collection, function(schema) {
+        schema.options.toJSON.returnAllTranslations = true;
+      });
       res.send(exportObject);
+      eachSchema(req.collection, function(schema) {
+        schema.options.toJSON.returnAllTranslations = false;
+      });
     });
   });
 
@@ -98,6 +105,45 @@ function popitApiApp(options) {
         filename = options.instanceName + '-popolo-export.json.gz';
       } else {
         filename = 'popolo-export.json.gz';
+      }
+      res.attachment(filename);
+      var buf = new Buffer(JSON.stringify(exportObject), 'utf8');
+      zlib.gzip(buf, function(err, result) {
+        if (err) {
+          return next(err);
+        }
+        res.end(result);
+      });
+    });
+  });
+
+  // Export an individual language, this should be valid popolo
+  app.get('/export-:language.json', function(req, res, next) {
+    exporter(req.db, function(err, exportObject) {
+      if (err) {
+        return next(err);
+      }
+      eachSchema(req.collection, function(schema) {
+        schema.options.toJSON.langs = [req.params.language];
+      });
+      res.send(exportObject);
+    });
+  });
+
+  // Export an individual language, this should be valid popolo
+  app.get('/export-:language.json.gz', function(req, res, next) {
+    exporter(req.db, function(err, exportObject) {
+      if (err) {
+        return next(err);
+      }
+      eachSchema(req.collection, function(schema) {
+        schema.options.toJSON.langs = [req.params.language];
+      });
+      var filename;
+      if (options.instanceName) {
+        filename = options.instanceName + '-popolo-export-' + req.params.language + '.json.gz';
+      } else {
+        filename = 'popolo-export-' + req.params.language + '.json.gz';
       }
       res.attachment(filename);
       var buf = new Buffer(JSON.stringify(exportObject), 'utf8');

--- a/src/app.js
+++ b/src/app.js
@@ -93,7 +93,13 @@ function popitApiApp(options) {
       if (err) {
         return next(err);
       }
-      res.attachment('export.json.gz');
+      var filename;
+      if (options.instanceName) {
+        filename = options.instanceName + '-popolo-export.json.gz';
+      } else {
+        filename = 'popolo-export.json.gz';
+      }
+      res.attachment(filename);
       var buf = new Buffer(JSON.stringify(exportObject), 'utf8');
       zlib.gzip(buf, function(err, result) {
         if (err) {

--- a/src/app.js
+++ b/src/app.js
@@ -66,6 +66,7 @@ function popitApiApp(options) {
   app.use(dateFilter);
   app.use(accept);
   app.use(i18n(options.defaultLanguage));
+  app.use(apiLinks(options));
 
   app.get('*', cors());
 
@@ -125,7 +126,6 @@ function popitApiApp(options) {
    * Handle hidden fields on collections.
    */
   app.param('collection', hiddenFields);
-  app.param('collection', apiLinks(options));
 
   app.get('/search/:collection', function(req, res, next) {
     var pagination = paginate(req.query);

--- a/src/exporter.js
+++ b/src/exporter.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var async = require('async');
+require('./models');
+
+/**
+ * Takes a mongoose connection and returns an object with all the collections
+ * to the callback.
+ *
+ * @param {Connection} connection A mongoose connection object
+ * @param {function} callback The function to call with the exported object
+ */
+function exporter(connection, callback) {
+  function exportCollection(name) {
+    return function(done) {
+      connection.model(name).find({}, {memberships: 0}, done);
+    };
+  }
+
+  async.parallel({
+    persons: exportCollection('Person'),
+    organizations: exportCollection('Organization'),
+    memberships: exportCollection('Membership'),
+    posts: exportCollection('Post'),
+  }, callback);
+}
+
+module.exports = exporter;

--- a/test/exporter.js
+++ b/test/exporter.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var assert = require('assert');
+var mongoose = require('mongoose');
+var fixture = require('./fixture');
+var defaults = require('./defaults');
+
+var exporter = require('../src/exporter');
+
+describe("exporting popolo json", function() {
+  before(function() {
+    mongoose.connect('mongodb://localhost/' + defaults.databaseName);
+  });
+
+  after(function(done) {
+    mongoose.connection.close(done);
+  });
+
+  beforeEach(fixture.loadFixtures);
+
+  it("includes all data", function(done) {
+    exporter(mongoose, function(err, data) {
+      assert.ifError(err);
+      assert.equal(data.persons.length, 2);
+      assert.equal(data.organizations.length, 2);
+      assert.equal(data.memberships.length, 2);
+      assert.equal(data.posts.length, 2);
+      done();
+    });
+  });
+
+});

--- a/test/rest.js
+++ b/test/rest.js
@@ -9,6 +9,7 @@ var supertest     = require("supertest"),
     serverApp     = require("../test-server-app"),
     person        = require('./util').person,
     mongoose      = require('mongoose'),
+    zlib          = require('zlib'),
     dropElasticsearchIndex = require('./util').dropElasticsearchIndex,
     refreshElasticsearchIndex = require('./util').refreshElasticsearchIndex,
     apiApp = require('..');
@@ -769,6 +770,60 @@ describe("REST", function () {
         assert.ifError(err);
         assert.equal(res.body.errors[0], "The merge method currently only works with people");
         done();
+      });
+    });
+
+  });
+
+  describe("export", function() {
+    beforeEach(fixture.loadFixtures);
+
+    it("provides popolo json", function(done) {
+      request.get('/api/export.json')
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(2, res.body.persons.length);
+        assert.equal(2, res.body.organizations.length);
+        assert.equal(2, res.body.memberships.length);
+        assert.equal(2, res.body.posts.length);
+        done();
+      });
+    });
+
+    /**
+     * Parser for binary responses
+     *
+     * @see http://stackoverflow.com/a/14802413
+     */
+    function binaryParser(res, callback) {
+      res.setEncoding('binary');
+      res.data = '';
+      res.on('data', function(chunk) {
+        res.data += chunk;
+      });
+      res.on('end', function() {
+        callback(null, new Buffer(res.data, 'binary'));
+      });
+    }
+
+    it("provides compressed popolo json", function(done) {
+      request.get('/api/export.json.gz')
+      .expect(200)
+      .parse(binaryParser)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal('application/octet-stream', res.header['content-type']);
+        assert(res.header['content-disposition'].indexOf('export.json.gz') !== -1);
+        zlib.unzip(res.body, function(err, json) {
+          assert.ifError(err);
+          var popolo = JSON.parse(json);
+          assert.equal(2, popolo.persons.length);
+          assert.equal(2, popolo.organizations.length);
+          assert.equal(2, popolo.memberships.length);
+          assert.equal(2, popolo.posts.length);
+          done();
+        });
       });
     });
 


### PR DESCRIPTION
This allow the user to export all of their data in popolo format. There are 4 different endpoints for the export

- `/export.json` - All languages uncompressed - this will produce invalid popolo if the instance uses multiple language, but is portable between instances.
- `export.json.gz` - As above but gzipped
- `export-:language.json` - Just one `:language` uncompressed - this will produce valid popolo but can't be used on it's own to recreate a whole instance and its translations.
- `export-:language.json.gz` - As above but gzipped.

Part of #321
