### PR TITLE
include link to image proxy version with images

### DIFF
--- a/src/middleware/api-links.js
+++ b/src/middleware/api-links.js
@@ -11,6 +11,7 @@ module.exports = apiLinksMiddleware;
  * @param {Object} options The options to configure this function
  * @param {String} options.baseUrl The url where the main app is located
  * @param {String} options.apiBaseUrl The url where the API is mounted
+ * @param {String} options.proxyBaseUrl The url of the image proxy
  * @return {Function} Express compatible middleware.
  */
 function apiLinksMiddleware(options) {
@@ -18,6 +19,7 @@ function apiLinksMiddleware(options) {
     eachSchema(req.db, function(schema) {
       schema.options.toJSON.baseUrl = options.baseUrl;
       schema.options.toJSON.apiBaseUrl = options.apiBaseUrl;
+      schema.options.toJSON.proxyBaseUrl = options.proxyBaseUrl;
     });
     next();
   };

--- a/src/mongoose/json-transform.js
+++ b/src/mongoose/json-transform.js
@@ -90,6 +90,15 @@ function generateImageUrl(img, doc, options) {
   return url;
 }
 
+function generateImageProxyUrl(img, doc, options) {
+  var url = [
+    options.proxyBaseUrl,
+    encodeURIComponent(img.url),
+  ].join('/');
+
+  return url;
+}
+
 function setImage(doc, ret, options) {
   var images = ret.images;
 
@@ -99,9 +108,15 @@ function setImage(doc, ret, options) {
       if (!img.url) {
         img.url = generateImageUrl(img, doc, options);
       }
+      if (options.proxyBaseUrl && !img.proxy_url) {
+        img.proxy_url = generateImageProxyUrl(img, doc, options);
+      }
       ret.images.push(img);
     });
     ret.image = ret.images[0].url;
+    if ( options.proxyBaseUrl ) {
+      ret.proxy_image = ret.images[0].proxy_url;
+    }
   }
 
   return ret;


### PR DESCRIPTION
If the proxyBaseUrl option is set then we include a link as a proxy_url
key for each image to the base proxy url of images so CPI clients can
link to thumbnailed versions. It doesn't include any resizing parameters
which the clients will need to add themselves.

Fixes #mysociety/popit/707