### PR TITLE
add cors middleware and apply to API GET requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "JSV": "~4.0.2",
     "async": "~0.2.6",
+    "cors": ">=2.5.2",
     "doublemetaphone": "~0.1.2",
     "elasticsearch": "~1.5.1",
     "express": "~3.17.5",

--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,7 @@ var models = require('./models');
 var eachSchema = require('./utils').eachSchema;
 var InvalidQueryError = require('./mongoose/elasticsearch').InvalidQueryError;
 var async = require('async');
+var cors = require('cors');
 var InvalidEmbedError = require('./mongoose/embed').InvalidEmbedError;
 var MergeConflictError = require('./mongoose/merge').MergeConflictError;
 
@@ -63,6 +64,8 @@ function popitApiApp(options) {
   app.use(dateFilter);
   app.use(accept);
   app.use(i18n(options.defaultLanguage));
+
+  app.get('*', cors());
 
   app.get('/', function (req, res) {
     res.jsonp({


### PR DESCRIPTION
by default adds Access-Control-Allow-Origin: * to all GET requests
which means API calls work in ajax calls etc

Fixes mysociety/popit#691