### PR TITLE
Switch the API to use body-parser and multer

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "JSV": "~4.0.2",
     "async": "~0.2.6",
+    "body-parser": "^1.10.1",
     "cors": ">=2.5.2",
     "doublemetaphone": "~0.1.2",
     "elasticsearch": "~1.5.1",
@@ -29,6 +30,7 @@
     "mkdirp": "~ 0.3.1",
     "mongoose": "~3.8.5",
     "mpath": "~0.2.1",
+    "multer": "^0.1.6",
     "underscore": "~1.4.4",
     "underscore.string": "~2.3.1",
     "unorm": "~1.3.1"

--- a/src/app.js
+++ b/src/app.js
@@ -27,6 +27,8 @@ var InvalidEmbedError = require('./mongoose/embed').InvalidEmbedError;
 var MergeConflictError = require('./mongoose/merge').MergeConflictError;
 var exporter = require('./exporter');
 var zlib = require('zlib');
+var bodyParser = require('body-parser');
+var multer = require('multer');
 
 module.exports = popitApiApp;
 
@@ -51,7 +53,9 @@ function popitApiApp(options) {
     next();
   });
 
-  app.use(express.bodyParser());
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(multer());
 
   app.use(storageSelector(options));
 


### PR DESCRIPTION
Because the UI is now using these modules it processes the request before it gets to the API, which seems to confuse the old bodyParser middleware and throws an error.

The simple solution is to switch the API to use the same modules as the UI.

Fixes https://github.com/mysociety/popit/issues/718