### PR TITLE
Replace existing document on PUT request

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -666,7 +666,7 @@ function popitApiApp(options) {
         return next(err);
       }
       if (!doc) {
-        doc = new req.collection();
+        doc = new req.collection({ _id: id });
       }
       delete body.__v;
 
@@ -690,7 +690,7 @@ function popitApiApp(options) {
       if ( body.image && !body.images ) {
         body.images = [ { url: body.image } ];
       }
-      doc.update(body, {overwrite: true}, function(err) {
+      doc.update(body, { upsert: true, overwrite: true }, function(err) {
         if (err) {
           return next(err);
         }

--- a/src/app.js
+++ b/src/app.js
@@ -690,12 +690,16 @@ function popitApiApp(options) {
       if ( body.image && !body.images ) {
         body.images = [ { url: body.image } ];
       }
-      doc.set(body);
-      doc.save(function(err) {
+      doc.update(body, {overwrite: true}, function(err) {
         if (err) {
           return next(err);
         }
-        res.withBody(doc);
+        req.collection.findById(id, function(err, doc) {
+          if (err) {
+            return next(err);
+          }
+          res.withBody(doc);
+        });
       });
     });
 

--- a/test/rest.js
+++ b/test/rest.js
@@ -374,6 +374,26 @@ describe("REST", function () {
           .end(done);
       });
 
+      it("should replace the whole document", function(done) {
+        request
+          .put("/api/persons/test")
+          .send({ name: "Joe Bloggs", meme: "Harlem Shake" }) // name should be string
+          .expect(200)
+          .end(function(err, res) {
+            assert.ifError(err);
+            request
+              .put("/api/persons/test")
+              .send({ name: "Joe Bloggs", foo: "Bar" }) // name should be string
+              .expect(200)
+              .end(function(err, res) {
+                assert.ifError(err);
+                assert.equal(res.body.result.foo, "Bar")
+                assert(!res.body.result.meme, "meme property should have been overwritten");
+                done();
+              });
+          });
+      });
+
     });
 
 


### PR DESCRIPTION
Rather than just updating the changed members we replace the whole document on PUT requests. This matches the proper semantics for a PUT request, but is also a backwards incompatible change, so needs to be included in a new version of the API.

Will squash down the commits after review.

Fixes #95 