### PR TITLE
Preserve ?embed and ?q parameters when paginating

### DIFF
--- a/src/paginate.js
+++ b/src/paginate.js
@@ -4,6 +4,19 @@ var url = require('url');
 
 module.exports = paginate;
 
+// We want to preserve these query string parameters when paginating.
+var queryParamsToKeep = ['per_page', 'embed', 'q'];
+
+function filterQuery(query) {
+  var filtered = {};
+  queryParamsToKeep.forEach(function(param) {
+    if (query[param] !== undefined) {
+      filtered[param] = query[param];
+    }
+  });
+  return filtered;
+}
+
 /**
  * Turns page/per_page parameters into mongo-friendly skip/limit parameters.
  *
@@ -40,13 +53,8 @@ function paginate(options) {
     if (currentUrl) {
       var parsedUrl = url.parse(currentUrl, true);
       delete parsedUrl.search;
-      var currentPerPage = parsedUrl.query.per_page;
 
-      parsedUrl.query = {};
-
-      if (currentPerPage) {
-        parsedUrl.query.per_page = currentPerPage;
-      }
+      parsedUrl.query = filterQuery(parsedUrl.query);
 
       if (hasMore) {
         parsedUrl.query.page = (page + 1);

--- a/test/paginate.js
+++ b/test/paginate.js
@@ -87,5 +87,23 @@ describe("paginate", function() {
       metadata = pagination.metadata(42, 'http://example.org/api/persons?page=2&callback=jQuery999');
       assert.equal(metadata.prev_url, 'http://example.org/api/persons?page=1');
     });
+
+    it("preserves useful params such as ?embed and ?q", function() {
+      pagination = paginate({ page: 1 });
+      metadata = pagination.metadata(42, 'http://example.org/api/persons?embed=membership.person');
+      assert.equal(metadata.next_url, 'http://example.org/api/persons?embed=membership.person&page=2');
+
+      pagination = paginate({ page: 1 });
+      metadata = pagination.metadata(42, 'http://example.org/api/search/persons?q=Bob');
+      assert.equal(metadata.next_url, 'http://example.org/api/search/persons?q=Bob&page=2');
+
+      pagination = paginate({ page: 1 });
+      metadata = pagination.metadata(42, 'http://example.org/api/search/persons?embed=membership.person&q=Bob');
+      assert.equal(metadata.next_url, 'http://example.org/api/search/persons?embed=membership.person&q=Bob&page=2');
+
+      pagination = paginate({ page: 1 });
+      metadata = pagination.metadata(42, 'http://example.org/api/search/persons?embed=&q=Bob');
+      assert.equal(metadata.next_url, 'http://example.org/api/search/persons?embed=&q=Bob&page=2');
+    });
   });
 });


### PR DESCRIPTION
When paginating we don't want to keep all parameters because it can cause issue with jQuery's JSONP functionality (see 186c09bf738e4299bf4386864e3cd02e4cc6b7b5).

We do however want to keep user supplied parameters such as how many results per_page, what to embed and the q parameter for the current search.

This ensures that these parameters are kept and makes it easy to add other parameters to keep in the future.

Fixes #110 