### PR TITLE
Allow embedding the post for a membership

### DIFF
--- a/src/mongoose/embed.js
+++ b/src/mongoose/embed.js
@@ -95,6 +95,10 @@ function embedPlugin(schema) {
         path: 'memberships.organization_id',
         model: 'Organization',
       },
+      'membership.post': {
+        path: 'memberships.post_id',
+        model: 'Post',
+      },
     };
 
     var invalidTargets = !_.all(targets, function(target) { return target_map[target]; });


### PR DESCRIPTION
Allow embedding posts referred to by memberships.

This seems so overly simple, I'm not sure why I didn't do it in the first place. It could well be that I'm missing something, but this appears to have the desired effect.

Fixes #111 