### PR TITLE
Add export_url to API metadata

### DIFF
--- a/src/routes/info.js
+++ b/src/routes/info.js
@@ -17,6 +17,7 @@ module.exports = function(app, options) {
         organizations_api_url: baseUrl + '/organizations',
         memberships_api_url: baseUrl + '/memberships',
         posts_api_url: baseUrl + '/posts',
+        export_url: baseUrl + '/export.json',
         image_proxy_url: proxyBaseUrl
       },
     });

--- a/test/apps.js
+++ b/test/apps.js
@@ -74,6 +74,7 @@ describe("Apps", function () {
               organizations_api_url: '/organizations',
               memberships_api_url: '/memberships',
               posts_api_url: '/posts',
+              export_url: '/export.json',
               image_proxy_url: ''
             },
           })

--- a/test/rest.js
+++ b/test/rest.js
@@ -59,6 +59,7 @@ describe("REST", function () {
             organizations_api_url: '/organizations',
             memberships_api_url: '/memberships',
             posts_api_url: '/posts',
+            export_url: '/export.json',
             image_proxy_url: ''
           },
         })


### PR DESCRIPTION
As suggested in https://github.com/mysociety/popit/pull/703#issuecomment-69002984 this adds the export url to the API's metadata endpoint.