### PR TITLE
Fix url generation race condition

### DIFF
--- a/src/middleware/api-links.js
+++ b/src/middleware/api-links.js
@@ -16,11 +16,9 @@ module.exports = apiLinksMiddleware;
  */
 function apiLinksMiddleware(options) {
   return function apiLinks(req, res, next) {
-    eachSchema(req.db, function(schema) {
-      schema.options.toJSON.baseUrl = options.baseUrl;
-      schema.options.toJSON.apiBaseUrl = options.apiBaseUrl;
-      schema.options.toJSON.proxyBaseUrl = options.proxyBaseUrl;
-    });
+    req.baseUrl = options.baseUrl;
+    req.apiBaseUrl = options.apiBaseUrl;
+    req.proxyBaseUrl = options.proxyBaseUrl;
     next();
   };
 }

--- a/src/middleware/api-links.js
+++ b/src/middleware/api-links.js
@@ -1,9 +1,5 @@
 "use strict";
 
-var eachSchema = require('../utils').eachSchema;
-
-module.exports = apiLinksMiddleware;
-
 /**
  * If the apiBaseUrl argument is given then configure the models to include
  * links in their output.
@@ -22,3 +18,5 @@ function apiLinksMiddleware(options) {
     next();
   };
 }
+
+module.exports = apiLinksMiddleware;

--- a/src/models.js
+++ b/src/models.js
@@ -107,7 +107,7 @@ MembershipSchema.methods.toElasticsearch = function(callback) {
 
 // This method doesn't do anything, it just provides the same interface as
 // the other models get from the membershipFinder plugin.
-MembershipSchema.methods.populateMemberships = function populateMemberships(callback) {
+MembershipSchema.methods.populateMemberships = function populateMemberships(_req, callback) {
   callback();
 };
 

--- a/src/mongoose/json-transform.js
+++ b/src/mongoose/json-transform.js
@@ -17,30 +17,9 @@ function jsonTransformPlugin(schema) {
  */
 function filterFields(doc, ret, options) {
   ret = filter(doc, ret, options);
-  ret = addLinks(doc, ret, options);
   ret = translateDoc(doc, ret, options);
   ret = filterDates(doc, ret, options);
   ret = setImage(doc, ret, options);
-  return ret;
-}
-
-function addLinks(doc, ret, options) {
-  if (doc.constructor.collection) {
-    if (options.apiBaseUrl) {
-      ret.url = [
-        options.apiBaseUrl,
-        doc.constructor.collection.name.toLowerCase(),
-        doc._id || doc.id
-      ].join('/');
-    }
-    if (options.baseUrl && (doc._id || doc.id)) {
-      ret.html_url = [
-        options.baseUrl,
-        doc.constructor.collection.name.toLowerCase(),
-        doc._id || doc.id
-      ].join('/');
-    }
-  }
   return ret;
 }
 

--- a/src/mongoose/membership-finder.js
+++ b/src/mongoose/membership-finder.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var async = require("async");
+var transform = require('../transform');
 
 /**
  * Find memberships that are associated with the current object and
@@ -26,12 +27,15 @@ function membershipFinder(schema, options) {
     Membership.find({$or: queries}, callback);
   };
 
-  schema.methods.populateMemberships = function populateMemberships(callback) {
+  schema.methods.populateMemberships = function populateMemberships(req, callback) {
     var self = this;
     this.findMemberships(function(err, memberships) {
       if (err) {
         return callback(err);
       }
+      memberships = memberships.map(function(membership) {
+        return transform(membership, req);
+      });
       self.memberships = memberships;
       callback();
     });

--- a/src/routes/collection.get.js
+++ b/src/routes/collection.get.js
@@ -14,7 +14,7 @@ module.exports = function(app) {
       }
 
       async.each(docs, function(doc, done) {
-        doc.embedDocuments(req.query.embed, done);
+        doc.embedDocuments(req, done);
       }, function(err) {
         if (err) {
           return next(err);

--- a/src/routes/collection.get.js
+++ b/src/routes/collection.get.js
@@ -2,6 +2,7 @@
 
 var async = require('async');
 var paginate = require('../paginate');
+var transform = require('../transform');
 
 module.exports = function(app) {
 
@@ -24,6 +25,9 @@ module.exports = function(app) {
             return next(err);
           }
           var body = pagination.metadata(count, req.currentUrl);
+          docs.forEach(function(doc) {
+            transform(doc, req);
+          });
           body.result = docs;
           res.jsonp(body);
         });

--- a/src/routes/collection.post.js
+++ b/src/routes/collection.post.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var validateBody = require('../middleware/validate-body');
+var transform = require('../transform');
 
 module.exports = function(app) {
 
@@ -15,7 +16,7 @@ module.exports = function(app) {
       if (err) {
         return next(err);
       }
-      res.withBody(doc);
+      res.withBody(transform(doc, req));
     });
 
   });

--- a/src/routes/document.get.js
+++ b/src/routes/document.get.js
@@ -41,7 +41,7 @@ module.exports = function(app) {
         return res.jsonp(404, {errors: ["id '" + id + "' not found"]});
       }
 
-      doc.embedDocuments(req.query.embed, function(err) {
+      doc.embedDocuments(req, function(err) {
         if (err instanceof InvalidEmbedError) {
           // Send a 400 error to indicate the client needs to alter their request
           return res.send(400, {errors: [err.message, err.explaination]});

--- a/src/routes/document.get.js
+++ b/src/routes/document.get.js
@@ -2,6 +2,7 @@
 
 var eachSchema = require('../utils').eachSchema;
 var InvalidEmbedError = require('../mongoose/embed').InvalidEmbedError;
+var transform = require('../transform');
 
 module.exports = function(app) {
 
@@ -20,7 +21,7 @@ module.exports = function(app) {
         schema.options.toJSON.returnAllTranslations = true;
       });
 
-      res.withBody(doc);
+      res.withBody(transform(doc, req));
 
       eachSchema(req.collection, function(schema) {
         schema.options.toJSON.returnAllTranslations = false;
@@ -48,7 +49,7 @@ module.exports = function(app) {
         if (err) {
           return next(err);
         }
-        res.withBody(doc);
+        res.withBody(transform(doc, req));
       });
     });
   });

--- a/src/routes/document.put.js
+++ b/src/routes/document.put.js
@@ -2,6 +2,7 @@
 
 var mongoose = require('mongoose');
 var validateBody = require('../middleware/validate-body');
+var transform = require('../transform');
 
 module.exports = function(app) {
 
@@ -53,7 +54,7 @@ module.exports = function(app) {
         if (err) {
           return next(err);
         }
-        res.withBody(doc);
+        res.withBody(transform(doc, req));
       });
     });
 

--- a/src/routes/merge.js
+++ b/src/routes/merge.js
@@ -2,7 +2,7 @@
 
 var async = require('async');
 var MergeConflictError = require('../mongoose/merge').MergeConflictError;
-
+var transform = require('../transform');
 
 module.exports = function(app) {
 
@@ -47,7 +47,7 @@ module.exports = function(app) {
             if (err) {
               return next(err);
             }
-            res.withBody(person);
+            res.withBody(transform(person, req));
           });
         });
       });

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -3,6 +3,7 @@
 var paginate = require('../paginate');
 var async = require('async');
 var InvalidQueryError = require('../mongoose/elasticsearch').InvalidQueryError;
+var transform = require('../transform');
 
 module.exports = function(app) {
 
@@ -31,6 +32,9 @@ module.exports = function(app) {
         }
 
         var body = pagination.metadata(result.hits.total, req.currentUrl);
+        docs.forEach(function(doc) {
+          transform(doc, req);
+        });
         body.result = docs;
         res.jsonp(body);
       });

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -23,7 +23,7 @@ module.exports = function(app) {
       });
 
       async.each(docs, function(doc, done) {
-        doc.embedDocuments(req.query.embed, function() {
+        doc.embedDocuments(req, function() {
           doc.correctDates(done);
         });
       }, function(err) {

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,0 +1,28 @@
+"use strict";
+
+function addLinks(doc, options) {
+  if (doc.constructor.collection) {
+    if (options.apiBaseUrl) {
+      doc.set('url', [
+        options.apiBaseUrl,
+        doc.constructor.collection.name.toLowerCase(),
+        doc._id || doc.id
+      ].join('/'));
+    }
+    if (options.baseUrl && (doc._id || doc.id)) {
+      doc.set('html_url', [
+        options.baseUrl,
+        doc.constructor.collection.name.toLowerCase(),
+        doc._id || doc.id
+      ].join('/'));
+    }
+  }
+  return doc;
+}
+
+function transform(doc, options) {
+  doc = addLinks(doc, options);
+  return doc;
+}
+
+module.exports = transform;


### PR DESCRIPTION
Previously we were using `eachSchema` and `schema.options.toJSON` to set various configuration options which affected how the json was rendered by mongoose's `toJSON` method. This was a flawed approach because data could leak between requests if two instances were setting different option simultaneously.

This pull request moves the url generation into a `transform.js` module, which fixes the race condition with url generation and also should make it reasonably trivial to fix https://github.com/mysociety/popit-api/issues/119.

Fixes https://github.com/mysociety/popit/issues/729