### PR TITLE
Fix image proxy url

### DIFF
--- a/src/mongoose/json-transform.js
+++ b/src/mongoose/json-transform.js
@@ -19,7 +19,6 @@ function filterFields(doc, ret, options) {
   ret = filter(doc, ret, options);
   ret = translateDoc(doc, ret, options);
   ret = filterDates(doc, ret, options);
-  ret = setImage(doc, ret, options);
   return ret;
 }
 
@@ -55,61 +54,4 @@ function translateDoc(doc, ret, options) {
     return ret;
   }
   return i18n(ret, options.langs, options.defaultLanguage, options.includeTranslations);
-}
-
-
-function _generateUrl(parts) {
-  var url = parts.join('/');
-
-  // this is a bit grim but there doesn't seem to be a JS
-  // library to do this.
-  var reDoubleSlash = /([^:])\/\//g;
-  url = url.replace(reDoubleSlash, "$1/");
-
-  return url;
-}
-
-
-function generateImageUrl(img, doc, options) {
-  var parts = [
-    options.baseUrl,
-    doc.constructor.collection.name.toLowerCase(),
-    doc._id || doc.id,
-    'image',
-    img._id
-  ];
-
-  return _generateUrl(parts);
-}
-
-function generateImageProxyUrl(img, doc, options) {
-  var parts = [
-    options.proxyBaseUrl,
-    encodeURIComponent(img.url),
-  ];
-
-  return _generateUrl(parts);
-}
-
-function setImage(doc, ret, options) {
-  var images = ret.images;
-
-  if ( images && images.length ) {
-    ret.images = [];
-    doc.get('images').forEach(function imageProcess(img) {
-      if (!img.url) {
-        img.url = generateImageUrl(img, doc, options);
-      }
-      if (options.proxyBaseUrl && !img.proxy_url) {
-        img.proxy_url = generateImageProxyUrl(img, doc, options);
-      }
-      ret.images.push(img);
-    });
-    ret.image = ret.images[0].url;
-    if ( options.proxyBaseUrl ) {
-      ret.proxy_image = ret.images[0].proxy_url;
-    }
-  }
-
-  return ret;
 }

--- a/src/transform.js
+++ b/src/transform.js
@@ -20,8 +20,64 @@ function addLinks(doc, options) {
   return doc;
 }
 
+function _generateUrl(parts) {
+  var url = parts.join('/');
+
+  // this is a bit grim but there doesn't seem to be a JS
+  // library to do this.
+  var reDoubleSlash = /([^:])\/\//g;
+  url = url.replace(reDoubleSlash, "$1/");
+
+  return url;
+}
+
+function generateImageUrl(img, doc, options) {
+  var parts = [
+    options.baseUrl,
+    doc.constructor.collection.name.toLowerCase(),
+    doc._id || doc.id,
+    'image',
+    img._id
+  ];
+
+  return _generateUrl(parts);
+}
+
+function generateImageProxyUrl(img, doc, options) {
+  var parts = [
+    options.proxyBaseUrl,
+    encodeURIComponent(img.url),
+  ];
+
+  return _generateUrl(parts);
+}
+
+function setImage(doc, ret, options) {
+  var images = ret.images;
+
+  if ( images && images.length ) {
+    ret.images = [];
+    doc.get('images').forEach(function imageProcess(img) {
+      if (!img.url) {
+        img.url = generateImageUrl(img, doc, options);
+      }
+      if (options.proxyBaseUrl && !img.proxy_url) {
+        img.proxy_url = generateImageProxyUrl(img, doc, options);
+      }
+      ret.images.push(img);
+    });
+    ret.image = ret.images[0].url;
+    if ( options.proxyBaseUrl ) {
+      ret.proxy_image = ret.images[0].proxy_url;
+    }
+  }
+
+  return ret;
+}
+
 function transform(doc, options) {
   doc = addLinks(doc, options);
+  doc = setImage(doc, options);
   return doc;
 }
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -52,27 +52,25 @@ function generateImageProxyUrl(img, doc, options) {
   return _generateUrl(parts);
 }
 
-function setImage(doc, ret, options) {
-  var images = ret.images;
-
-  if ( images && images.length ) {
-    ret.images = [];
-    doc.get('images').forEach(function imageProcess(img) {
-      if (!img.url) {
-        img.url = generateImageUrl(img, doc, options);
-      }
-      if (options.proxyBaseUrl && !img.proxy_url) {
-        img.proxy_url = generateImageProxyUrl(img, doc, options);
-      }
-      ret.images.push(img);
-    });
-    ret.image = ret.images[0].url;
-    if ( options.proxyBaseUrl ) {
-      ret.proxy_image = ret.images[0].proxy_url;
+function setImage(doc, options) {
+  var images = doc.get('images');
+  if (!images || images.length === 0) {
+    return doc;
+  }
+  images.forEach(function imageProcess(img) {
+    if (!img.url) {
+      img.url = generateImageUrl(img, doc, options);
     }
+    if (options.proxyBaseUrl && !img.proxy_url) {
+      img.proxy_url = generateImageProxyUrl(img, doc, options);
+    }
+  });
+  doc.set('image', images[0].url);
+  if ( options.proxyBaseUrl ) {
+    doc.set('proxy_image', images[0].proxy_url);
   }
 
-  return ret;
+  return doc;
 }
 
 function transform(doc, options) {


### PR DESCRIPTION
Following on from https://github.com/mysociety/popit-api/pull/120 and https://github.com/mysociety/popit/issues/729 this moves the image_proxy bits into the new transform module.

Fixes https://github.com/mysociety/popit/issues/736