### PR TITLE
Set id last so it doesn't get overwritten when filtering

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -17,10 +17,6 @@ function filter(doc, ret, options) {
 
   var newDoc = {};
 
-  if (doc._id) {
-    newDoc.id = doc._id;
-  }
-
   for (var field in ret) {
     // Skip any fields that have been hidden on this doc.
     if (fields[ret._id]) {
@@ -43,5 +39,11 @@ function filter(doc, ret, options) {
     // If we've made it this far then copy the field to the new doc.
     newDoc[field] = ret[field];
   }
+
+  // Set the 'id' last so it doesn't get overwritten by the 'id' of 'ret'
+  if (doc._id) {
+    newDoc.id = doc._id;
+  }
+
   return newDoc;
 }

--- a/test/rest.js
+++ b/test/rest.js
@@ -317,6 +317,25 @@ describe("REST", function () {
           .end(done);
       });
 
+      describe("when id and _id don't match for some reason", function() {
+        beforeEach(function(done) {
+          mongoose.model('Membership').create({
+            _id: 'abc',
+            id: '123',
+          }, done);
+        });
+
+        it("should always return the correct id", function(done) {
+          request
+            .get("/api/v0.1/memberships/abc")
+            .expect(200, function(err, res) {
+              assert.ifError(err);
+              assert.equal(res.body.result.id, "abc");
+              done();
+            });
+        });
+      });
+
     });
 
     describe("POST", function () {


### PR DESCRIPTION
The filter module was setting the id property of the returned document
first, then proceeding to iterate through the whole document and copy
properties across. This meant that when the document had an 'id' field
that didn't match the '_id' field (for whatever reason) it was
overwriting the 'id' property with an incorrect one.

This fix ensures that the returned document will always have the correct
id property matching the _id in the database. There is still the mystery
of how the ids came to differ in the first place, but at least this
masks that problem.

Fixes https://github.com/mysociety/popit/issues/730