### PR TITLE
Upgrade express to 3.19.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cors": ">=2.5.2",
     "doublemetaphone": "~0.1.2",
     "elasticsearch": "~1.5.1",
-    "express": "~3.17.5",
+    "express": "~3.19.2",
     "fs-extra": "~ 0.10.0",
     "http-accept": "~0.1.6",
     "language-tags": "~1.0.2",


### PR DESCRIPTION
This fixes the security issue with serve-static because this version of
express depends on a newer version of connect, which in turn depends on
a version of serve-static which isn't vulnerable to the open redirect
issue.

Fixes https://github.com/mysociety/popit/issues/742