### PR TITLE
Add bulk delete endpoints to the API

### DIFF
--- a/src/mongoose/elasticsearch.js
+++ b/src/mongoose/elasticsearch.js
@@ -131,6 +131,24 @@ function elasticsearchPlugin(schema) {
     return this.modelName.toLowerCase();
   };
 
+  schema.statics.deleteFromElasticsearch = function deleteFromElasticsearch(callback) {
+    var indexName = this.indexName();
+    var typeName = this.typeName();
+    client.indices.existsType({
+      type: typeName,
+      index: indexName,
+    }, function(err, res, status) {
+      if (status === 404) {
+        // Index doesn't exist
+        return process.nextTick(callback);
+      }
+      client.indices.deleteMapping({
+        index: indexName,
+        type: typeName,
+      }, callback);
+    });
+  };
+
   /**
    * Add a search method to models that use this plugin.
    *

--- a/src/routes/delete.js
+++ b/src/routes/delete.js
@@ -7,7 +7,12 @@ function bulkDelete(req, res, next) {
     if (err) {
       return next(err);
     }
-    res.send(204);
+    req.collection.deleteFromElasticsearch(function(err) {
+      if (err) {
+        return next(err);
+      }
+      res.send(204);
+    });
   });
 }
 
@@ -19,7 +24,13 @@ function bulkDeleteAll(req, res, next) {
     'Post',
   ];
   async.each(collections, function deleteCollection(collection, done) {
-    req.db.model(collection).remove(done);
+    var Model = req.db.model(collection);
+    Model.remove(function(err) {
+      if (err) {
+        return done(err);
+      }
+      Model.deleteFromElasticsearch(done);
+    });
   }, function(err) {
     if (err) {
       return next(err);

--- a/src/routes/delete.js
+++ b/src/routes/delete.js
@@ -1,0 +1,36 @@
+"use strict";
+
+var async = require('async');
+
+function bulkDelete(req, res, next) {
+  req.collection.remove(function(err) {
+    if (err) {
+      return next(err);
+    }
+    res.send(204);
+  });
+}
+
+function bulkDeleteAll(req, res, next) {
+  var collections = [
+    'Person',
+    'Organization',
+    'Membership',
+    'Post',
+  ];
+  async.each(collections, function deleteCollection(collection, done) {
+    req.db.model(collection).remove(done);
+  }, function(err) {
+    if (err) {
+      return next(err);
+    }
+    res.send(204);
+  });
+}
+
+function setup(app) {
+  app.delete('/:collection', bulkDelete);
+  app.delete('/', bulkDeleteAll);
+}
+
+module.exports = setup;

--- a/src/versions/0.1.js
+++ b/src/versions/0.1.js
@@ -26,6 +26,7 @@ function popitApiApp(options) {
   require('../routes/document.get')(app);
   require('../routes/document.delete')(app);
   require('../routes/document.put')(app);
+  require('../routes/delete')(app);
 
   // Error handling
   app.use(function(err, req, res, next) {


### PR DESCRIPTION
This allows you to remove all the people, organizations, memberships and posts from an instance in one go. Alternatively you can just remove the records from an individual collection.

Fixes https://github.com/mysociety/popit/issues/464