### PR TITLE
Run CORS preflight check before auth happens

### DIFF
--- a/src/app-setup.js
+++ b/src/app-setup.js
@@ -33,6 +33,9 @@ module.exports = function(app, options) {
     next();
   });
 
+  // Allow openpoliticians to do imports over CORS
+  app.use('/imports', require('./openpoliticians'));
+
   app.use(bodyParser.json({ limit: '50mb' }));
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(multer());
@@ -51,9 +54,6 @@ module.exports = function(app, options) {
   app.use(accept);
   app.use(i18n(options.defaultLanguage));
   app.use(apiLinks(options));
-
-  // Allow openpoliticians to do imports over CORS
-  app.use('/imports', require('./openpoliticians'));
 
   app.get('*', cors());
 };


### PR DESCRIPTION
This makes it easier to trap auth errors on the client side by checking
the status code of the actual response, rather than the 401 being on the
preflight check.

Fixes https://github.com/mysociety/popit/issues/776