### PR TITLE
Allow openpoliticians full CORS permissions

### DIFF
--- a/src/app-setup.js
+++ b/src/app-setup.js
@@ -33,8 +33,8 @@ module.exports = function(app, options) {
     next();
   });
 
-  // Allow openpoliticians to do imports over CORS
-  app.use('/imports', require('./openpoliticians'));
+  // Allow openpoliticians to access the API using CORS
+  app.use(require('./openpoliticians'));
 
   app.use(bodyParser.json({ limit: '50mb' }));
   app.use(bodyParser.urlencoded({ extended: true }));


### PR DESCRIPTION
Open Politicians needs to do things other than the import such as bulk
delete from an instance before performing the import. This change allows
it full access to the API.

Note that this change is *only* for Open Politicians, no other sites
will be able to access the site over CORS.