### PR TITLE
Encode record id whenever it's included in a url

### DIFF
--- a/src/routes/document.get.js
+++ b/src/routes/document.get.js
@@ -6,7 +6,7 @@ var transform = require('../transform');
 
 module.exports = function(app) {
 
-  app.get('/:collection/:id(*)/full', function (req, res, next) {
+  app.get('/:collection/:id/full', function (req, res, next) {
     var id = req.params.id;
 
     req.collection.findById(id, function (err, doc) {
@@ -29,7 +29,7 @@ module.exports = function(app) {
     });
   });
 
-  app.get('/:collection/:id(*)', function (req, res, next) {
+  app.get('/:collection/:id', function (req, res, next) {
     var id = req.params.id;
 
     req.collection.findById(id)

--- a/src/transform.js
+++ b/src/transform.js
@@ -6,14 +6,14 @@ function addLinks(doc, options) {
       doc.set('url', [
         options.apiBaseUrl,
         doc.constructor.collection.name.toLowerCase(),
-        doc._id || doc.id
+        encodeURIComponent(doc._id || doc.id),
       ].join('/'));
     }
     if (options.baseUrl && (doc._id || doc.id)) {
       doc.set('html_url', [
         options.baseUrl,
         doc.constructor.collection.name.toLowerCase(),
-        doc._id || doc.id
+        encodeURIComponent(doc._id || doc.id),
       ].join('/'));
     }
   }


### PR DESCRIPTION
This ensures that '?', '/' and other characters are properly encoded in the url so there are no accidental 404s.

Part of https://github.com/mysociety/popit/issues/769