### PR TITLE
Allow one to determine the position of an uploaded image in 'images'

### DIFF
--- a/src/routes/image.js
+++ b/src/routes/image.js
@@ -127,8 +127,17 @@ module.exports = function(app) {
         if ( typeof idx != 'undefined' ) {
           images[idx] = image;
         } else {
-          images.push(image);
+          if (image.index === 'first') {
+            images.unshift(image);
+          } else if (image.index === 'last') {
+            images.push(image);
+          } else if (/^(0|[1-9]\d*)$/.test(image.index)) {
+            images.splice(parseInt(image.index), 0, image);
+          } else {
+            images.push(image);
+          }
         }
+        delete image.index;
 
         doc.set('images', images);
         // mongoose has trouble working out if mixed object arrays have changed


### PR DESCRIPTION
The behaviour when you upload an image via the PopIt API at the moment
is that it is appended to the 'images' array.  It would be helpful to be
able to instead say that the image should be inserted at the front of
the 'images' array, so that it's the "primary" image for that person
(i.e. the one that is used for the 'image' property)

This commit introduces a special parameter called 'index' when POSTing a
new image, which can be either set to 'first', 'last', '0', '1', '2',
'3', etc. to insert the image at the start of 'images', the end of
'images' or at a specific index (where 0 is the first place in the
array).