### PR TITLE
Fix image ids in API output

### DIFF
--- a/src/mongoose/popolo.js
+++ b/src/mongoose/popolo.js
@@ -1,10 +1,20 @@
 "use strict";
 
+var mongoose = require('mongoose');
 var mongooseJsonSchema = require('./json-schema');
 var jsonTransform = require('./json-transform').jsonTransformPlugin;
 var search = require('./search');
 var elasticsearch = require('./elasticsearch');
 var embed = require('./embed');
+
+var ImageSchema = new mongoose.Schema({
+  created: Date,
+  url: String,
+  source: String,
+  license: String,
+  note: String,
+  mime_type: String,
+}, { strict: false });
 
 function popoloPlugin(schema, options) {
   schema.plugin(mongooseJsonSchema, {jsonSchemaUrl: options.popoloSchemaUrl});
@@ -16,6 +26,8 @@ function popoloPlugin(schema, options) {
   schema.statics.popoloSchemaUrl = function popoloSchemaUrl() {
     return options.popoloSchemaUrl;
   };
+
+  schema.add({ images: [ImageSchema] });
 }
 
 module.exports = popoloPlugin;

--- a/test/date-filter.js
+++ b/test/date-filter.js
@@ -63,7 +63,8 @@ describe("Filter by date", function() {
           start_date: '2009-10-10',
           end_date: '2010-10-10',
           links: [],
-          contact_details: []
+          contact_details: [],
+          images: []
         }
       ]);
       done();

--- a/test/rest-v0.1.js
+++ b/test/rest-v0.1.js
@@ -131,9 +131,9 @@ describe("REST API v0.1", function () {
               has_more: false,
               result: [
                 { id: 'oldMP', post_id: 'avalon', organization_id: 'commons', role: 'Member of Parliament',
-                  member: {'@type': 'Person', id: 'fred-bloggs'}, start_date: '2000', end_date: '2004', links: [], contact_details: [] },
+                  member: {'@type': 'Person', id: 'fred-bloggs'}, start_date: '2000', end_date: '2004', links: [], contact_details: [], images: [] },
                 { id: 'backAsMP', post_id: 'avalon', organization_id: 'commons', role: 'Member of Parliament',
-                  member: {'@type': 'Person', id: 'fred-bloggs'}, start_date: '2011', links: [], contact_details: [] },
+                  member: {'@type': 'Person', id: 'fred-bloggs'}, start_date: '2011', links: [], contact_details: [], images: [] },
               ],
             })
             .end(done);
@@ -247,19 +247,26 @@ describe("REST API v0.1", function () {
           .post("/api/v0.1/persons")
           .send({id: 'test', name: 'Test', images: [ { url: 'http://example.com/image.png' }]})
           .expect(200)
-          .expect({
-            result: person({id: 'test', name: 'Test', image: 'http://example.com/image.png', images: [ { url: 'http://example.com/image.png' }]})
-          }, done);
+          .end(function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.body.result.image, 'http://example.com/image.png');
+            done();
+          });
       });
 
-      it("should return an set the image attribute to the first image from images", function(done) {
+      it("should return and set the image attribute to the first image from images", function(done) {
         request
           .post("/api/v0.1/persons")
           .send({id: 'test', name: 'Test', images: [ { url: 'http://example.com/image.png' }, { url: 'http://example.org/image2.png' } ]})
           .expect(200)
-          .expect({
-            result: person({id: 'test', name: 'Test', image: 'http://example.com/image.png', images: [ { url: 'http://example.com/image.png' }, { url: 'http://example.org/image2.png' } ]})
-          }, done);
+          .end(function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.body.result.images.length, 2);
+            assert.equal(res.body.result.images[0].url, 'http://example.com/image.png');
+            assert.equal(res.body.result.images[1].url, 'http://example.org/image2.png');
+            assert.equal(res.body.result.image, 'http://example.com/image.png');
+            done();
+          });
       });
 
       it("should add an image to the images array", function(done) {
@@ -267,9 +274,13 @@ describe("REST API v0.1", function () {
           .post("/api/v0.1/persons")
           .send({id: 'test', name: 'Test', image: 'http://example.com/image.png' })
           .expect(200)
-          .expect({
-            result: person({id: 'test', name: 'Test', image: 'http://example.com/image.png', images: [ { url: 'http://example.com/image.png' }]})
-          }, done);
+          .end(function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.body.result.images.length, 1);
+            assert.equal(res.body.result.images[0].url, 'http://example.com/image.png');
+            assert.equal(res.body.result.image, 'http://example.com/image.png');
+            done();
+          });
       });
 
     });

--- a/test/util.js
+++ b/test/util.js
@@ -13,6 +13,7 @@ function person(attrs) {
   attrs.contact_details = [];
   attrs.identifiers = [];
   attrs.other_names = [];
+  attrs.images = attrs.images || [];
   return attrs;
 }
 


### PR DESCRIPTION
Make sure the images ids in the API output are correct. When there is no schema defined the API doesn't know what to do with the _id field, so it serializes it to an object instead of a string.

Eventually I'd like all of the schemas in popit-api to be explicit like this (see https://github.com/mysociety/popit/issues/264#issuecomment-85448579 for more details on whats involved with that).

Fixes https://github.com/mysociety/popit/issues/470