### PR TITLE
Cast incoming image ids to ObjectIds

### DIFF
--- a/src/routes/1.0/document.put.js
+++ b/src/routes/1.0/document.put.js
@@ -40,7 +40,9 @@ module.exports = function(app) {
       if ( body.images ) {
         var images = [];
         body.images.forEach( function(img) {
-          if ( img._id ) {
+          if (img.id) {
+            img._id = new mongoose.Types.ObjectId(img.id);
+          } else if ( img._id ) {
             img._id = new mongoose.Types.ObjectId(img._id);
           }
           images.push(img);

--- a/src/routes/document.put.js
+++ b/src/routes/document.put.js
@@ -36,7 +36,9 @@ module.exports = function(app) {
       if ( body.images ) {
         var images = [];
         body.images.forEach( function(img) {
-          if ( img._id ) {
+          if (img.id) {
+            img._id = new mongoose.Types.ObjectId(img.id);
+          } else if ( img._id ) {
             img._id = new mongoose.Types.ObjectId(img._id);
           }
           images.push(img);

--- a/test/rest-v0.1.js
+++ b/test/rest-v0.1.js
@@ -393,6 +393,21 @@ describe("REST API v0.1", function () {
           .end(done);
       });
 
+      it("should allow specifying image ids in hex ObjectId format", function(done) {
+        var Person = mongoose.model('Person');
+        request
+        .put("/api/v0.1/persons/test")
+        .send({id: 'test', name: 'Test', images: [{ id: '55119bc1a69347a221956989', url: 'http://example.com/image.png' }] })
+        .expect(200)
+        .end(function(err) {
+          assert.ifError(err);
+          Person.findById('test', function(err, person) {
+            assert.ifError(err);
+            assert.equal(person.get('images')[0]._id, '55119bc1a69347a221956989');
+            done();
+          });
+        });
+      });
     });
 
 


### PR DESCRIPTION
When PUTing an update to a record the id field of each object in the images array should be cast to a mongo ObjectId if present.

Fixes https://github.com/mysociety/popit/issues/794