### PR TITLE
Disallow non-image uploads & ignore the supplied mime_type

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "kue": "^0.8.11",
     "language-tags": "~1.0.2",
     "mkdirp": "~ 0.3.1",
+    "mmmagic": "^0.3.13",
     "mongodb": "=1.4.28",
     "mongoose": "~3.8.5",
     "mpath": "~0.2.1",

--- a/src/routes/image.js
+++ b/src/routes/image.js
@@ -141,16 +141,19 @@ module.exports = function(app) {
         }
         delete image.index;
 
-        /* In case no MIME type was specified on upload, guess it
-         * using libmagic */
-        magic.detectFile(dest_path, function(err, result) {
+        /* Get the file's MIME type using libmagic */
+        magic.detectFile(dest_path, function(err, mimeType) {
           if (err) {
             return next(new Error("Finding the MIME type of the image failed"));
           }
 
-          if (!image.mime_type) {
-            image.mime_type = result;
+          if (!/^image\//.test(mimeType)) {
+            return next(new Error(
+              "The uploaded image was of non-permitted type: " + mimeType
+            ));
           }
+
+          image.mime_type = mimeType;
 
           doc.set('images', images);
           // mongoose has trouble working out if mixed object arrays have changed

--- a/src/routes/image.js
+++ b/src/routes/image.js
@@ -3,6 +3,8 @@
 var fs = require('fs-extra');
 var mkdirp = require('mkdirp');
 var path = require('path');
+var mmm = require('mmmagic');
+var magic = new mmm.Magic(mmm.MAGIC_MIME_TYPE);
 var transform = require('../transform');
 
 module.exports = function(app) {
@@ -139,17 +141,29 @@ module.exports = function(app) {
         }
         delete image.index;
 
-        doc.set('images', images);
-        // mongoose has trouble working out if mixed object arrays have changed
-        // so make sure it knows otherwise the changes aren't saved
-        doc.markModified('images');
-
-        doc.save(function(err, newDoc) {
+        /* In case no MIME type was specified on upload, guess it
+         * using libmagic */
+        magic.detectFile(dest_path, function(err, result) {
           if (err) {
-            return next(err);
+            return next(new Error("Finding the MIME type of the image failed"));
           }
 
-          return res.withBody(transform(newDoc, req));
+          if (!image.mime_type) {
+            image.mime_type = result;
+          }
+
+          doc.set('images', images);
+          // mongoose has trouble working out if mixed object arrays have changed
+          // so make sure it knows otherwise the changes aren't saved
+          doc.markModified('images');
+
+          doc.save(function(err, newDoc) {
+            if (err) {
+              return next(err);
+            }
+
+            return res.withBody(transform(newDoc, req));
+          });
         });
       });
     }


### PR DESCRIPTION
It seems unnecessary to trust the user of the API to get the MIME type
of an uploaded image correct, when we can infer the file type using
libmagic. (And this saves documenting the mime_type parameter...)

Since libmagic just looks for invariant magic numbers at fixed offsets
into binary files (to paraphrase the man page), it can't tell whether
a file is malformed (possibly maliciously), but this was a risk with
the existing code anyway, and if a browser or image library is subject
to buffer overruns or the like that's a much more serious problem than
just that PopIt might store and serve such a file.

In addition this makes sure that newly uploaded files will only be
served with an image/* Content-Type.  (Existing uploaded images will
still be served with whatever mime_type was specified on upload.)

Fixes mysociety/popit#810