### PR TITLE
Use .set to add url and proxy_url to the image

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -59,10 +59,10 @@ function setImage(doc, options) {
   }
   images.forEach(function imageProcess(img) {
     if (!img.url) {
-      img.url = generateImageUrl(img, doc, options);
+      img.set('url', generateImageUrl(img, doc, options));
     }
     if (options.proxyBaseUrl && !img.proxy_url) {
-      img.proxy_url = generateImageProxyUrl(img, doc, options);
+      img.set('proxy_url', generateImageProxyUrl(img, doc, options));
     }
   });
   doc.set('image', images[0].url);


### PR DESCRIPTION
This is required because the images are now a model and setting unknown
attributes on a model requires the use of `.set`.

Fixes https://github.com/mysociety/popit/issues/811