### PR TITLE
Fix proxy image property

### DIFF
--- a/src/routes/1.0/collection.post.js
+++ b/src/routes/1.0/collection.post.js
@@ -2,6 +2,7 @@
 
 var async = require('async');
 var validateBody = require('../../middleware/validate-body');
+var transform = require('../../transform');
 
 var tidyUpInlineMembershipError = require('../../inline-memberships').tidyUpInlineMembershipError;
 var processMembership = require('../../inline-memberships').processMembership;
@@ -45,13 +46,13 @@ module.exports = function(app) {
                   return res.send(400, {errors: [err]});
                 });
               } else {
-                res.withBody(doc);
+                res.withBody(transform(doc, req));
               }
             });
           }
         });
       } else {
-        res.withBody(doc);
+        res.withBody(transform(doc, req));
       }
     });
   });

--- a/src/transform.js
+++ b/src/transform.js
@@ -67,7 +67,7 @@ function setImage(doc, options) {
   });
   doc.set('image', images[0].url);
   if ( options.proxyBaseUrl ) {
-    doc.set('proxy_image', images[0].proxy_url);
+    doc.set('proxy_image', images[0].get('proxy_url'));
   }
 
   return doc;

--- a/test/rest-v0.1.js
+++ b/test/rest-v0.1.js
@@ -283,6 +283,25 @@ describe("REST API v0.1", function () {
           });
       });
 
+
+      it("should add proxy_url to image objects and proxy_image to top level", function(done) {
+        var apiRequest = supertest(apiApp({
+          databaseName: defaults.databaseName,
+          apiBaseUrl: 'http://example.org',
+          proxyBaseUrl: 'http://example.org/image-proxy',
+        }));
+        apiRequest
+          .post("/v0.1/persons")
+          .send({id: 'test', name: 'Test', images: [ { url: 'http://example.com/image.png' }]})
+          .expect(200)
+          .end(function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.body.result.images[0].proxy_url, 'http://example.org/image-proxy/http%3A%2F%2Fexample.com%2Fimage.png');
+            assert.equal(res.body.result.proxy_image, 'http://example.org/image-proxy/http%3A%2F%2Fexample.com%2Fimage.png');
+            done();
+          });
+      });
+
     });
 
     describe("PUT", function () {

--- a/test/rest-v1.0.0.js
+++ b/test/rest-v1.0.0.js
@@ -6,6 +6,7 @@ var serverApp = require('../test-server-app');
 var assert = require('assert');
 var mongoose = require('mongoose');
 var defaults = require('./defaults');
+var apiApp = require('..');
 
 var request = supertest(serverApp);
 
@@ -539,6 +540,28 @@ describe("REST API v1.0.0-alpha", function () {
           });
         });
     });
+
+  });
+
+  describe("images", function() {
+
+      it("should add proxy_url to image objects and proxy_image to top level", function(done) {
+        var apiRequest = supertest(apiApp({
+          databaseName: defaults.databaseName,
+          apiBaseUrl: 'http://example.org',
+          proxyBaseUrl: 'http://example.org/image-proxy',
+        }));
+        apiRequest
+          .post("/v1.0.0-alpha/persons")
+          .send({id: 'test', name: 'Test', images: [ { url: 'http://example.com/image.png' }]})
+          .expect(200)
+          .end(function(err, res) {
+            assert.ifError(err);
+            assert.equal(res.body.result.images[0].proxy_url, 'http://example.org/image-proxy/http%3A%2F%2Fexample.com%2Fimage.png');
+            assert.equal(res.body.result.proxy_image, 'http://example.org/image-proxy/http%3A%2F%2Fexample.com%2Fimage.png');
+            done();
+          });
+      });
 
   });
 


### PR DESCRIPTION
This adds back the `proxy_image` property to the top level of each document by using `.get` to access the `proxy_url` on the images array. It also adds some tests to ensure there are no future regressions and in doing so fixes a problem with the 1.0.0-alpha version of the API, which wasn't passing responses through the transform module for post requests.