### PR TITLE
Allow comma separated embeds

### DIFF
--- a/test/rest-v0.1.js
+++ b/test/rest-v0.1.js
@@ -777,6 +777,17 @@ describe("REST API v0.1", function () {
       });
     });
 
+    it("embeds organization and post if requested", function(done) {
+      request.get('/api/v0.1/persons/fred-bloggs?embed=membership.organization,membership.post')
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships[0].organization_id.name, 'House of Commons');
+        assert.equal(res.body.result.memberships[0].post_id.label, 'MP for Avalon');
+        done();
+      });
+    });
+
   });
 
   describe("merging people", function() {

--- a/test/rest-v1.0.0.js
+++ b/test/rest-v1.0.0.js
@@ -521,6 +521,17 @@ describe("REST API v1.0.0-alpha", function () {
         done();
       });
     });
+
+    it("embeds organization and post if requested", function(done) {
+      request.get('/api/v1.0.0-alpha/persons/fred-bloggs?embed=membership.organization,membership.post')
+      .expect(200)
+      .end(function(err, res) {
+        assert.ifError(err);
+        assert.equal(res.body.result.memberships[0].organization.name, 'House of Commons');
+        assert.equal(res.body.result.memberships[0].post.label, 'MP for Avalon');
+        done();
+      });
+    });
   });
 
   describe("PUT", function() {


### PR DESCRIPTION
Allow specifying multiple things to embed in a membership by separating them with a comma.

    /persons/bob?embed=membership.organization,membership.post

:memo: This diff is easier to read [without whitespace changes](https://github.com/mysociety/popit-api/pull/143/files?w=0)

Fixes https://github.com/mysociety/popit/issues/797