### PR TITLE
Use transform to add urls before exporting

### DIFF
--- a/src/routes/export.js
+++ b/src/routes/export.js
@@ -6,7 +6,7 @@ var exporter = require('../exporter');
 module.exports = function(app) {
   // Export all languages - can potentially produce invalid popolo
   app.get('/export.json', function(req, res, next) {
-    exporter(req.db, function(err, exportObject) {
+    exporter(req.db, req, function(err, exportObject) {
       if (err) {
         return next(err);
       }
@@ -16,7 +16,7 @@ module.exports = function(app) {
   });
 
   app.get('/export.json.gz', function(req, res, next) {
-    exporter(req.db, function(err, exportObject) {
+    exporter(req.db, req, function(err, exportObject) {
       if (err) {
         return next(err);
       }
@@ -39,7 +39,7 @@ module.exports = function(app) {
 
   // Export an individual language, this should be valid popolo
   app.get('/export-:language.json', function(req, res, next) {
-    exporter(req.db, function(err, exportObject) {
+    exporter(req.db, req, function(err, exportObject) {
       if (err) {
         return next(err);
       }
@@ -50,7 +50,7 @@ module.exports = function(app) {
 
   // Export an individual language, this should be valid popolo
   app.get('/export-:language.json.gz', function(req, res, next) {
-    exporter(req.db, function(err, exportObject) {
+    exporter(req.db, req, function(err, exportObject) {
       if (err) {
         return next(err);
       }

--- a/test/exporter.js
+++ b/test/exporter.js
@@ -19,7 +19,7 @@ describe("exporting popolo json", function() {
   beforeEach(fixture.loadFixtures);
 
   it("includes all data", function(done) {
-    exporter(mongoose, function(err, data) {
+    exporter(mongoose, {}, function(err, data) {
       assert.ifError(err);
       assert.equal(data.persons.length, 2);
       assert.equal(data.organizations.length, 2);


### PR DESCRIPTION
By running documents through the transform module before we create the
export we can add the url, html_url and various image related urls to
the json.

Fixes https://github.com/mysociety/popit/issues/827